### PR TITLE
Store unittest result, test and manifest as part of test tasks

### DIFF
--- a/mozci/push.py
+++ b/mozci/push.py
@@ -198,12 +198,18 @@ class Push:
                     task['_groups'] = [task['_groups']]
 
             if task.get('_result_ok'):
-                if '_result_group' not in task:
-                    task['_result_group'] = [None] * len(task["_result_test"])
-                task['_results'] = [TestResult(group=group, test=test, ok=ok) for group, test, ok in zip(task["_result_group"], task["_result_test"], task["_result_ok"])]
-                del task['_result_ok']
-                del task['_result_test']
-                del task['_result_group']
+                if '_result_group' in task:
+                    groups = task.pop('_result_group')
+                else:
+                    groups = [None] * len(task['_result_test'])
+
+                tests = task.pop('_result_test')
+                oks = task.pop('_result_ok')
+
+                task['_results'] = [
+                    TestResult(group=group, test=test, ok=ok)
+                    for group, test, ok in zip(groups, tests, oks)
+                ]
 
             normalized_tasks.append(task)
 

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -200,7 +200,7 @@ class Push:
             if task.get('_result_ok'):
                 if '_result_group' not in task:
                     task['_result_group'] = [None] * len(task["_result_test"])
-                task['results'] = [TestResult(group=group, test=test, ok=ok) for group, test, ok in zip(task["_result_group"], task["_result_test"], task["_result_ok"])]
+                task['_results'] = [TestResult(group=group, test=test, ok=ok) for group, test, ok in zip(task["_result_group"], task["_result_test"], task["_result_ok"])]
                 del task['_result_ok']
                 del task['_result_test']
                 del task['_result_group']

--- a/mozci/queries/push_tasks_from_unittest.query
+++ b/mozci/queries/push_tasks_from_unittest.query
@@ -3,6 +3,9 @@ select:
     - {name: id, value: task.id}
     - {name: kind, value: task.kind}
     - {name: _groups, value: run.suite.groups}
+    - {name: _result_group, value: result.group}
+    - {name: _result_test, value: result.test}
+    - {name: _result_ok, value: result.ok}
 where:
     and:
         - prefix: {repo.changeset.id: {$eval: rev}}

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -68,7 +68,15 @@ class Task:
 
 
 @dataclass
+class TestResult:
+    group: str
+    test: str
+    ok: bool
+
+
+@dataclass
 class TestTask(Task):
+    results: List[TestResult] = field(default_factory=list)
     _groups: List = field(default_factory=list)
 
     @property

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -91,9 +91,13 @@ class TestTask(Task):
 
         results = {}
         for line in lines[1:]:
-            results[line['test']] = (line['group'] if 'group' in line else None, line['expected'] == line['status'])
+            results[line['test']] = (
+                line['group'] if 'group' in line else None, line['expected'] == line['status']
+            )
 
-        self._results = [TestResult(group=group, test=test, ok=ok) for test, (group, ok) in results.items()]
+        self._results = [
+            TestResult(group=group, test=test, ok=ok) for test, (group, ok) in results.items()
+        ]
 
     @property
     def groups(self):


### PR DESCRIPTION
I was unable to test this normally, as in all pushes I tried to analyze, most tasks were skipped because of missing fields.