### PR TITLE
Retrieve groups from the unittest table with a separate query, to get them only once per task

### DIFF
--- a/mozci/push.py
+++ b/mozci/push.py
@@ -192,7 +192,12 @@ class Push:
         # artifacts.
         # TODO: We have fallbacks for groups and results, but not for kind.
         try:
-            add(run_query('push_tasks_from_unittest', args)['data'])
+            add(run_query('push_tasks_results_from_unittest', args)['data'])
+        except MissingDataError:
+            pass
+
+        try:
+            add(run_query('push_tasks_groups_from_unittest', args)['data'])
         except MissingDataError:
             pass
 

--- a/mozci/queries/push_tasks_from_treeherder.query
+++ b/mozci/queries/push_tasks_from_treeherder.query
@@ -14,6 +14,5 @@ where:
         - ne: {run.result: "retry"}
         - ne: {job.type.name: "Gecko Decision Task"}
         - not: {prefix: {job.type.name: "Action"}}
+limit: 10000
 format: list
-destination: url
-limit: 1000000

--- a/mozci/queries/push_tasks_groups_from_unittest.query
+++ b/mozci/queries/push_tasks_groups_from_unittest.query
@@ -1,0 +1,15 @@
+from: unittest
+select:
+    - {name: id, value: task.id}
+    - {name: kind, value: task.kind}
+    - {name: _groups, value: run.suite.groups}
+where:
+    and:
+        - eq: {etl.id: 0}
+        - prefix: {repo.changeset.id: {$eval: rev}}
+        - eq: {repo.branch.name: {$eval: branch}}
+        - ne: {treeherder.tier: 3}
+        - ne: {task.kind: "decision-task"}
+limit: 10000000
+format: list
+destination: url

--- a/mozci/queries/push_tasks_groups_from_unittest.query
+++ b/mozci/queries/push_tasks_groups_from_unittest.query
@@ -10,6 +10,5 @@ where:
         - eq: {repo.branch.name: {$eval: branch}}
         - ne: {treeherder.tier: 3}
         - ne: {task.kind: "decision-task"}
-limit: 10000000
+limit: 10000
 format: list
-destination: url

--- a/mozci/queries/push_tasks_results_from_unittest.query
+++ b/mozci/queries/push_tasks_results_from_unittest.query
@@ -1,8 +1,6 @@
 from: unittest
 select:
     - {name: id, value: task.id}
-    - {name: kind, value: task.kind}
-    - {name: _groups, value: run.suite.groups}
     - {name: _result_group, value: result.group}
     - {name: _result_test, value: result.test}
     - {name: _result_ok, value: result.ok}


### PR DESCRIPTION
This considerably reduces the amount of data we have to pull from ActiveData.