### PR TITLE
Use 'fixed by commit' and back-out information to correctly attribute some regressions

### DIFF
--- a/mozci/push.py
+++ b/mozci/push.py
@@ -29,7 +29,7 @@ BASE_INDEX = "gecko.v2.{branch}.revision.{rev}"
 MAX_DEPTH = 14
 
 
-def get_hgmo(branch, rev):
+def get_automation_relevance(branch, rev):
     url = HGMO_AUTOMATION_RELEVANCE_URL.format(branch=branch, rev=rev)
     r = requests.get(url)
     r.raise_for_status()
@@ -46,7 +46,7 @@ def is_backout(branch, rev):
     if rev in backouts:
         return True
 
-    res = get_hgmo(branch, rev)
+    res = get_automation_relevance(branch, rev)
     if len(res["backsoutnodes"]) > 0:
         backouts.add(rev)
         return True

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -36,22 +36,17 @@ def get_automation_relevance(branch, rev):
     return r.json()["changesets"][0]
 
 
-backouts = set()
+backouts = {}
 
 
-@memoize
 def is_backout(branch, rev):
     global backouts
 
-    if rev in backouts:
-        return True
+    if rev not in backouts:
+        res = get_automation_relevance(branch, rev)
+        backouts[rev] = len(res["backsoutnodes"]) > 0
 
-    res = get_automation_relevance(branch, rev)
-    if len(res["backsoutnodes"]) > 0:
-        backouts.add(rev)
-        return True
-
-    return False
+    return backouts[rev]
 
 
 class Push:
@@ -88,7 +83,7 @@ class Push:
         if not backout_rev:
             return None
 
-        backouts.add(backout_rev)
+        backouts[backout_rev] = True
         return backout_rev
 
     @property

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -1,3 +1,4 @@
+import math
 from argparse import Namespace
 from collections import defaultdict
 
@@ -17,6 +18,7 @@ from mozci.task import (
 )
 from mozci.util.taskcluster import find_task_id
 
+HGMO_AUTOMATION_RELEVANCE_URL = "https://hg.mozilla.org/integration/{branch}/json-automationrelevance/{rev}"  # noqa
 HGMO_JSON_URL = "https://hg.mozilla.org/integration/{branch}/rev/{rev}?style=json"
 HGMO_JSON_PUSHES_URL = "https://hg.mozilla.org/integration/{branch}/json-pushes?version=2&startID={push_id_start}&endID={push_id_end}"  # noqa
 
@@ -25,6 +27,31 @@ BASE_INDEX = "gecko.v2.{branch}.revision.{rev}"
 # The maximum number of parents or children to look for previous/next task runs,
 # when the task did not run on the currently considered push.
 MAX_DEPTH = 14
+
+
+def get_hgmo(branch, rev):
+    url = HGMO_AUTOMATION_RELEVANCE_URL.format(branch=branch, rev=rev)
+    r = requests.get(url)
+    r.raise_for_status()
+    return r.json()["changesets"][0]
+
+
+backouts = set()
+
+
+@memoize
+def is_backout(branch, rev):
+    global backouts
+
+    if rev in backouts:
+        return True
+
+    res = get_hgmo(branch, rev)
+    if len(res["backsoutnodes"]) > 0:
+        backouts.add(rev)
+        return True
+
+    return False
 
 
 class Push:
@@ -56,7 +83,13 @@ class Push:
         Returns:
             str or None: The commit revision which backs this push out (or None).
         """
-        return self._hgmo.get('backedoutby') or None
+        global backouts
+        backout_rev = self._hgmo.get('backedoutby')
+        if not backout_rev:
+            return None
+
+        backouts.add(backout_rev)
+        return backout_rev
 
     @property
     def backedout(self):
@@ -197,7 +230,10 @@ class Push:
                         cur_task[key] = val
 
         # Gather information from the treeherder table.
-        add(run_query('push_tasks_from_treeherder', args))
+        try:
+            add(run_query('push_tasks_from_treeherder', args))
+        except MissingDataError:
+            pass
 
         # Gather information from the unittest table. We allow missing data for this table because
         # ActiveData only holds very recent data in it, but we have fallbacks on Taskcluster
@@ -232,6 +268,10 @@ class Push:
 
             if task.get('tags'):
                 task['tags'] = {t['name']: t['value'] for t in task['tags']}
+
+            if task.get('classification_note'):
+                if isinstance(task['classification_note'], list):
+                    task['classification_note'] = task['classification_note'][-1]
 
             if task.get('_groups'):
                 if isinstance(task['_groups'], str):
@@ -384,9 +424,33 @@ class Push:
                     passing_runnables.add(name)
                     continue
 
-                if all(c not in failclass for c in summary.classifications):
+                if all(c not in failclass for c, n in summary.classifications):
                     passing_runnables.add(name)
                     continue
+
+                fixed_by_commit_classification_notes = [
+                    n[:12] for c, n in summary.classifications if c == "fixed by commit"
+                ]
+                if len(fixed_by_commit_classification_notes) > 0:
+                    if (
+                        self.backedout
+                        and self.backedoutby[:12]
+                        in fixed_by_commit_classification_notes
+                    ):
+                        # If the failure was classified as fixed by commit, and the fixing commit
+                        # is a backout of the current push, it is definitely a regression of the
+                        # current push.
+                        candidate_regressions[name] = -math.inf
+                        continue
+                    elif all(
+                        is_backout(self.branch, note)
+                        for note in fixed_by_commit_classification_notes
+                    ):
+                        # If the failure was classified as fixed by commit, and the fixing commit
+                        # is a backout of another push, it is definitely not a regression of the
+                        # current push.
+                        passing_runnables.add(name)
+                        continue
 
                 if name in candidate_regressions:
                     # It failed in one of the pushes between the current and its
@@ -444,7 +508,7 @@ class Push:
                 total_count *= 2
 
             if not prior_regression and total_count <= MAX_DEPTH:
-                regressions[name] = total_count
+                regressions[name] = total_count if total_count > 0 else 0
 
         return regressions
 

--- a/mozci/queries/push_tasks_from_treeherder.query
+++ b/mozci/queries/push_tasks_from_treeherder.query
@@ -5,6 +5,7 @@ select:
     - {name: label, value: job.type.name}
     - {name: result, value: run.result}
     - {name: classification, value: failure.classification}
+    - {name: classification_note, value: failure.notes.text}
     - {name: duration, value: action.duration}
 where:
     and:

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -65,6 +65,7 @@ class Task:
     duration: int = field(default=None)
     result: str = field(default=None)
     classification: str = field(default=None)
+    classification_note: str = field(default=None)
     tags: Dict = field(default_factory=dict)
 
     @staticmethod
@@ -225,7 +226,7 @@ class GroupSummary(RunnableSummary):
 
     @property
     def classifications(self):
-        return set(t.classification for t in self.tasks if t.failed)
+        return [(t.classification, t.classification_note) for t in self.tasks if t.failed]
 
     @memoized_property
     def status(self):
@@ -272,7 +273,7 @@ class LabelSummary(RunnableSummary):
 
     @property
     def classifications(self):
-        return set(t.classification for t in self.tasks if t.failed)
+        return [(t.classification, t.classification_note) for t in self.tasks if t.failed]
 
     @memoized_property
     def status(self):

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -205,9 +205,8 @@ class TestTask(Task):
 @dataclass
 class RunnableSummary(ABC):
     @property
-    @abstractmethod
     def classifications(self):
-        ...
+        return [(t.classification, t.classification_note) for t in self.tasks if t.failed]
 
     @property
     @abstractmethod
@@ -223,10 +222,6 @@ class GroupSummary(RunnableSummary):
 
     def __post_init__(self):
         assert all(self.name in t.groups for t in self.tasks)
-
-    @property
-    def classifications(self):
-        return [(t.classification, t.classification_note) for t in self.tasks if t.failed]
 
     @memoized_property
     def status(self):
@@ -270,10 +265,6 @@ class LabelSummary(RunnableSummary):
 
     def __post_init__(self):
         assert all(t.label == self.label for t in self.tasks)
-
-    @property
-    def classifications(self):
-        return [(t.classification, t.classification_note) for t in self.tasks if t.failed]
 
     @memoized_property
     def status(self):


### PR DESCRIPTION
Fixes #2

A nice example to test this on is ee582f48caa16183f496f63dfd85eefb288ba4fb, you can see the difference before/after.