### PR TITLE
Skip 'default' group just like ActiveData does

### DIFF
--- a/mozci/task.py
+++ b/mozci/task.py
@@ -170,7 +170,7 @@ class TestTask(Task):
         lines = [json.loads(l) for l in self.get_artifact(path).splitlines()]
         for line in lines:
             if line['action'] == 'test_groups':
-                self._groups = line["groups"]
+                self._groups = list(set(line["groups"]) - {"default"})
 
             elif line['action'] == 'test_result':
                 self._results.append(GroupResult(


### PR DESCRIPTION
As in https://github.com/klahnakoski/ActiveData-ETL/blob/61a5a14deafc8babac37b2bc2d67c6bcc706e65a/activedata_etl/transforms/unittest_logs_to_sink.py#L228.