### PR TITLE
Stop asserting crashtest and geckoview-reftest tasks have no groups

### DIFF
--- a/mozci/task.py
+++ b/mozci/task.py
@@ -29,8 +29,6 @@ NO_GROUPS_SUITES = (
     "telemetry-tests",
     "firefox-ui-functional",
     "junit",
-    "crashtest",
-    "geckoview-reftest",
 )
 
 


### PR DESCRIPTION
Since https://bugzilla.mozilla.org/show_bug.cgi?id=1614640 has been fixed.