### PR TITLE
Stop running the integration tests as part of the default test set

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,10 @@ $ tox
 
 This should run successfully prior to submitting PRs (unless you need help figuring out the
 problem).
+
+There are also some integration tests that will hit live data sources. These are run in a cron task
+and are excluded from the default test run. But if needed, you can run them locally via:
+
+```bash
+$ tox -e integration
+```

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,9 +1,15 @@
 # -*- coding: utf-8 -*-
+import os
 from argparse import Namespace
 
+import pytest
 from adr.query import run_query
 
 from mozci import task
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("TRAVIS_EVENT_TYPE") != "cron", reason="Not run by a cron task"
+)
 
 
 def test_missing_manifests():

--- a/tox.ini
+++ b/tox.ini
@@ -3,12 +3,15 @@ isolated_build = true
 envlist = py37,pre-commit
 
 [testenv]
+envdir = {toxworkdir}/env
 deps = poetry
 setenv =
     ADR_CONFIG_PATH = tests/config.toml
+    integration: TRAVIS_EVENT_TYPE = cron
 commands =
   poetry install -v
-  poetry run pytest -v tests/
+  !integration: poetry run pytest -v tests/
+  integration:  poetry run pytest -v tests/test_integration.py
 
 [testenv:pre-commit]
 deps = pre-commit


### PR DESCRIPTION
Fixes #90