### PR TITLE
Handle `Push.rev` and `Push.revs` consistently

### DIFF
--- a/mozci/push.py
+++ b/mozci/push.py
@@ -33,19 +33,30 @@ class Push:
 
     def __init__(self, revs, branch="autoland"):
         if isinstance(revs, str):
+            self._revs = None
             revs = [revs]
+        else:
+            self._revs = revs
 
-        self.revs = revs
         self.branch = branch
-        self._hgmo = HGMO.create(self.rev, branch=self.branch)
-        self.index = BASE_INDEX.format(branch=self.branch, rev=self.rev)
+        self._hgmo = HGMO.create(revs[0], branch=self.branch)
 
         self._id = None
         self._date = None
 
+        # Need to use full hash in the index.
+        if len(revs[0]) == 40:
+            self.rev = revs[0]
+        else:
+            self.rev = self._hgmo["node"]
+
+        self.index = BASE_INDEX.format(branch=self.branch, rev=self.rev)
+
     @property
-    def rev(self):
-        return self.revs[0]
+    def revs(self):
+        if not self._revs:
+            self._revs = [c["node"] for c in self._hgmo.changesets]
+        return self._revs
 
     @memoized_property
     def backedoutby(self):

--- a/mozci/util/hgmo.py
+++ b/mozci/util/hgmo.py
@@ -18,14 +18,9 @@ class HGMO:
     CACHE = {}
 
     def __init__(self, rev, branch="autoland"):
-        self.rev = rev
-        self.branch = branch
-
         self.context = {
-            "branch": "integration/autoland"
-            if self.branch == "autoland"
-            else self.branch,
-            "rev": self.rev,
+            "branch": "integration/autoland" if branch == "autoland" else branch,
+            "rev": rev,
         }
 
     @staticmethod
@@ -44,9 +39,9 @@ class HGMO:
         return r.json()
 
     @property
-    def automation_relevance(self):
+    def changesets(self):
         url = self.AUTOMATION_RELEVANCE_TEMPLATE.format(**self.context)
-        return self._get_resource(url)["changesets"][0]
+        return self._get_resource(url)["changesets"]
 
     @property
     def data(self):
@@ -54,16 +49,10 @@ class HGMO:
         return self._get_resource(url)
 
     def __getitem__(self, k):
-        try:
-            return self.data[k]
-        except KeyError:
-            return self.automation_relevance[k]
+        return self.data[k]
 
     def get(self, k, default=None):
-        try:
-            return self[k]
-        except KeyError:
-            return default
+        return self.data.get(k, default)
 
     def json_pushes(self, push_id_start, push_id_end):
         url = self.JSON_PUSHES_TEMPLATE.format(
@@ -73,4 +62,4 @@ class HGMO:
 
     @property
     def is_backout(self):
-        return len(self.automation_relevance["backsoutnodes"]) > 0
+        return len(self.changesets[0]["backsoutnodes"]) > 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,24 +23,25 @@ def create_push(responses):
     prev_push = None
     push_id = 1
 
-    def inner(rev=None, branch="autoland", json=None, automationrelevance=None):
+    def inner(
+        rev=None, branch="integration/autoland", json=None, automationrelevance=None
+    ):
         nonlocal prev_push, push_id
 
         if not rev:
             rev = "rev{}".format(push_id)
 
-        push = Push(rev, branch)
-        push._id = push_id
-        push.backedoutby = None
-        push.tasks = []
+        if json is None:
+            json = {
+                "node": rev,
+            }
 
-        if json is not None:
-            responses.add(
-                responses.GET,
-                HGMO.JSON_TEMPLATE.format(branch=branch, rev=rev),
-                json=json,
-                status=200,
-            )
+        responses.add(
+            responses.GET,
+            HGMO.JSON_TEMPLATE.format(branch=branch, rev=rev),
+            json=json,
+            status=200,
+        )
 
         if automationrelevance is not None:
             responses.add(
@@ -49,6 +50,11 @@ def create_push(responses):
                 json=automationrelevance,
                 status=200,
             )
+
+        push = Push(rev, branch)
+        push._id = push_id
+        push.backedoutby = None
+        push.tasks = []
 
         if prev_push:
             push.parent = prev_push

--- a/tests/test_hgmo.py
+++ b/tests/test_hgmo.py
@@ -17,13 +17,6 @@ def test_hgmo_cache():
 def test_hgmo_is_backout(responses):
     responses.add(
         responses.GET,
-        "https://hg.mozilla.org/integration/autoland/rev/abcdef?style=json",
-        json={},
-        status=200,
-    )
-
-    responses.add(
-        responses.GET,
         "https://hg.mozilla.org/integration/autoland/json-automationrelevance/abcdef",
         json={"changesets": [{"backsoutnodes": []}]},
         status=200,
@@ -37,12 +30,12 @@ def test_hgmo_is_backout(responses):
     )
 
     h = HGMO("abcdef")
-    assert h["backsoutnodes"] == []
     assert not h.is_backout
+    assert h.changesets[0]["backsoutnodes"] == []
 
     h = HGMO("abcdef")
     assert h.is_backout
-    assert h["backsoutnodes"] == ["123456"]
+    assert h.changesets[0]["backsoutnodes"] == ["123456"]
 
 
 def test_hgmo_json_data(responses):

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -7,7 +7,7 @@ from mozci.task import Task
 from mozci.util.hgmo import HGMO
 
 
-@pytest.fixture(autouse=True, scope="module")
+@pytest.fixture(autouse=True)
 def reset_hgmo_cache():
     yield
     HGMO.CACHE = {}
@@ -383,7 +383,7 @@ def test_fixed_by_commit_no_backout(monkeypatch, create_pushes):
     """
 
     def mock_is_backout(cls):
-        if cls.context['rev'] == "xxx":
+        if cls.context["rev"] == "xxx":
             return False
 
         return True
@@ -604,6 +604,18 @@ def test_create_push(responses):
                 },
             },
         },
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        HGMO.JSON_TEMPLATE.format(branch="integration/autoland", rev="abcdef"),
+        json={"node": "abcdef"},
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        HGMO.JSON_TEMPLATE.format(branch="integration/autoland", rev="123456"),
+        json={"node": "123456"},
         status=200,
     )
 

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -383,7 +383,7 @@ def test_fixed_by_commit_no_backout(monkeypatch, create_pushes):
     """
 
     def mock_is_backout(cls):
-        if cls.rev == "xxx":
+        if cls.context['rev'] == "xxx":
             return False
 
         return True


### PR DESCRIPTION
The motivation here is to enforce more guarantees on the `rev` and `revs` properties. That it is the long form in the former, and that it exists at all in the latter.

This could potentially slow down performance, as it means we query `json-automationrelevance` in the `Push` constructor. I plan on using this fact to detect non-existent pushes early in a follow-up PR.

I theorize that we pretty much always need to query `json-automationrelevance` anyway, so my hope is that the overall perf impact is minimal.