### PR TITLE
Raise custom exceptions for common failure cases

### DIFF
--- a/mozci/errors.py
+++ b/mozci/errors.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+
+class BasePushException(Exception):
+    def __init__(self, rev, branch, msg):
+        self.rev = rev
+        self.branch = branch
+        self.msg = f"Error processing push '{rev}' on {branch}: {msg}"
+
+
+class PushNotFound(BasePushException):
+    """Raised when the requested push does not exist."""
+
+    def __init__(self, *args, **kwargs):
+        kwargs["msg"] = "does not exist!"
+        super(PushNotFound, self).__init__(*args, **kwargs)

--- a/mozci/errors.py
+++ b/mozci/errors.py
@@ -5,7 +5,7 @@ class BasePushException(Exception):
     def __init__(self, rev, branch, msg):
         self.rev = rev
         self.branch = branch
-        self.msg = f"Error processing push '{rev}' on {branch}: {msg}"
+        self.msg = f"Error with push '{rev}' on {branch}: {msg}"
 
 
 class PushNotFound(BasePushException):
@@ -14,3 +14,19 @@ class PushNotFound(BasePushException):
     def __init__(self, *args, **kwargs):
         kwargs["msg"] = "does not exist!"
         super(PushNotFound, self).__init__(*args, **kwargs)
+
+
+class BaseTaskException(Exception):
+    def __init__(self, id, label, msg):
+        self.id = id
+        self.label = label
+        self.msg = f"Error with task '{id}' ({label}): {msg}"
+
+
+class ArtifactNotFound(BaseTaskException):
+    """Raised when the requested task artifact does not exist."""
+
+    def __init__(self, artifact, *args, **kwargs):
+        kwargs["msg"] = f"artifact '{artifact}' does not exist!"
+        self.artifact = artifact
+        super(ArtifactNotFound, self).__init__(*args, **kwargs)

--- a/mozci/util/hgmo.py
+++ b/mozci/util/hgmo.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from adr.util.memoize import memoize
 
+from mozci.errors import PushNotFound
 from mozci.util.req import get_session
 
 
@@ -35,6 +36,10 @@ class HGMO:
     @memoize
     def _get_resource(self, url):
         r = get_session("hgmo").get(url)
+
+        if r.status_code == 404:
+            raise PushNotFound(**self.context)
+
         r.raise_for_status()
         return r.json()
 

--- a/mozci/util/taskcluster.py
+++ b/mozci/util/taskcluster.py
@@ -60,8 +60,12 @@ def get_artifact(task_id, path):
     """
     try:
         response = _do_request(get_artifact_url(task_id, path))
-    except requests.exceptions.HTTPError:
+    except requests.exceptions.HTTPError as e:
+        if e.response.status_code != 404:
+            raise
+
         response = _do_request(get_artifact_url(task_id, path, old_deployment=True))
+
     return _handle_artifact(path, response)
 
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from mozci.errors import ArtifactNotFound
+from mozci.task import Task
+from mozci.util.taskcluster import get_artifact_url
+
+
+@pytest.fixture
+def create_task():
+    id = 0
+
+    def inner(**kwargs):
+        nonlocal id
+        task = Task.create(id=id, **kwargs)
+        id += 1
+        return task
+
+    return inner
+
+
+def test_missing_artifacts(responses, create_task):
+    artifact = "public/artifact.txt"
+    task = create_task(label="foobar")
+
+    # First we'll check the new deployment.
+    responses.add(
+        responses.GET, get_artifact_url(task.id, artifact), status=404,
+    )
+
+    # Then we'll check the old deployment.
+    responses.add(
+        responses.GET,
+        get_artifact_url(task.id, artifact, old_deployment=True),
+        status=404,
+    )
+
+    with pytest.raises(ArtifactNotFound):
+        task.get_artifact(artifact)


### PR DESCRIPTION
Currently we don't do any exception handling, resulting in a mixture of confusing `KeyError`s and `requests.HTTPError`s being raised to the user.

We should catch these and re-raise them with Python 3's `raise from` syntax:
```
try:
   self._hgmo.get('rev')
except requests.HTTPError as e:
    if e.response.status_code == 404:
        raise PushNotFoundException from e
    raise
```