### PR TITLE
Switch from memoize to lru_cache

### DIFF
--- a/mozci/push.py
+++ b/mozci/push.py
@@ -3,10 +3,11 @@ import concurrent.futures
 import math
 from argparse import Namespace
 from collections import defaultdict
+from functools import lru_cache
 
 from adr.errors import MissingDataError
 from adr.query import run_query
-from adr.util.memoize import memoize, memoized_property
+from adr.util.memoize import memoized_property
 from loguru import logger
 
 from mozci.task import GroupResult, GroupSummary, LabelSummary, Status, Task, TestTask
@@ -373,7 +374,7 @@ class Push:
 
         return int(duration / 3600)
 
-    @memoize
+    @lru_cache(maxsize=None)
     def get_candidate_regressions(self, runnable_type):
         """Retrieve the set of "runnables" that are regression candidates for this push.
 
@@ -448,7 +449,7 @@ class Push:
 
         return candidate_regressions
 
-    @memoize
+    @lru_cache(maxsize=None)
     def get_regressions(self, runnable_type):
         """All regressions, both likely and definite.
 
@@ -533,7 +534,7 @@ class Push:
             if count == 0
         )
 
-    @memoize
+    @lru_cache(maxsize=None)
     def get_shadow_scheduler_tasks(self, name):
         """Returns all tasks the given shadow scheduler would have scheduled,
         or None if the given scheduler didn't run.

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -7,7 +7,7 @@ from enum import Enum
 from typing import Dict, List
 
 import requests
-from adr.util import memoize, memoized_property
+from adr.util import memoized_property
 from loguru import logger
 from urllib3.response import HTTPResponse
 
@@ -84,7 +84,6 @@ class Task:
         """List the artifacts that were uploaded by this task."""
         return [artifact["name"] for artifact in list_artifacts(self.id)]
 
-    @memoize
     def get_artifact(self, path):
         """Downloads and returns the content of an artifact.
 

--- a/mozci/util/hgmo.py
+++ b/mozci/util/hgmo.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from adr.util.memoize import memoize
+from functools import lru_cache
 
 from mozci.errors import PushNotFound
 from mozci.util.req import get_session
@@ -33,7 +33,7 @@ class HGMO:
         HGMO.CACHE[key] = instance
         return instance
 
-    @memoize
+    @lru_cache(maxsize=None)
     def _get_resource(self, url):
         r = get_session("hgmo").get(url)
 

--- a/mozci/util/req.py
+++ b/mozci/util/req.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
+from functools import lru_cache
+
 import requests
-from adr.util import memoize
 from requests.packages.urllib3.util.retry import Retry
 
 
-@memoize
+@lru_cache(maxsize=None)
 def get_session(name, concurrency=50):
     session = requests.Session()
 

--- a/mozci/util/taskcluster.py
+++ b/mozci/util/taskcluster.py
@@ -4,6 +4,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import functools
+from functools import lru_cache
 
 import requests
 import taskcluster_urls as liburls
@@ -49,6 +50,7 @@ def get_artifact_url(task_id, path, old_deployment=False):
         return f"https://queue.taskcluster.net/v1/task/{task_id}/artifacts/{path}"
 
 
+@lru_cache(maxsize=None)
 def get_artifact(task_id, path):
     """
     Returns the artifact with the given path for the given task id.


### PR DESCRIPTION
How do we know that it is working as expected?

On another note, look at [the second commit](https://github.com/mozilla/mozci/commit/5b1c326bbaa4c8793f4f5d6b3bcc32c2532bd045) and the output below.
I moved `@lru_cache` to the lower level function since it did not like using lru_cache as part of a function of a class.

```python
    def test_missing_artifacts(responses, create_task):
        artifact = "public/artifact.txt"
        task = create_task(label="foobar")
    
        # First we'll check the new deployment.
        responses.add(
            responses.GET, get_artifact_url(task.id, artifact), status=404,
        )
    
        # Then we'll check the old deployment.
        responses.add(
            responses.GET,
            get_artifact_url(task.id, artifact, old_deployment=True),
            status=404,
        )
    
        with pytest.raises(ArtifactNotFound):
>           task.get_artifact(artifact)
E           TypeError: unhashable type: 'Task'

tests/test_task.py:40: TypeError
============================================================================= short test summary info =============================================================================
FAILED tests/test_task.py::test_missing_artifacts - TypeError: unhashable type: 'Task'
```