### PR TITLE
Stop looking for failures in children pushes after we hit a backout of the push

### DIFF
--- a/mozci/push.py
+++ b/mozci/push.py
@@ -446,6 +446,8 @@ class Push:
                 candidate_regressions[name] = (count, summary.status)
 
             other = other.child
+            # Any failure that comes after this push has been backed-out, can't
+            # be blamed on this push.
             if self.backedoutby in other.revs:
                 break
             count += 1

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -446,6 +446,8 @@ class Push:
                 candidate_regressions[name] = (count, summary.status)
 
             other = other.child
+            if self.backedoutby in other.revs:
+                break
             count += 1
 
         return candidate_regressions

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,7 @@ def create_push(responses):
         push._id = push_id
         push.backedoutby = None
         push.tasks = []
+        push._revs = [push.rev]
 
         if prev_push:
             push.parent = prev_push


### PR DESCRIPTION
Fixes #101