### PR TITLE
[WIP] Penalize regressions that still occur on or after the backout of a push

### DIFF
--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -262,6 +262,109 @@ def test_failure_after_backout(monkeypatch, create_pushes):
     assert p[i + 2].get_regressions("label") == {"test-failure": 4}
 
 
+def test_failure_keeps_happening_on_backout(monkeypatch, create_pushes):
+    """
+    Tests the scenario where a task succeeded in a parent push, didn't run in the
+    push of interest and failed in a push after the backout of the push of interest.
+    """
+    p = create_pushes(4)
+    i = 1  # the index of the push we are mainly interested in
+
+    p[i - 1].tasks = [Task.create(id="1", label="test-failure", result="success")]
+    p[i].tasks = [
+        Task.create(
+            id="1",
+            label="test-failure",
+            result="testfailed",
+            classification="not classified",
+        )
+    ]
+    p[i].backedoutby = p[i + 2].rev
+    p[i + 1].tasks = []
+    p[i + 2].tasks = [
+        Task.create(
+            id="1",
+            label="test-failure",
+            result="testfailed",
+            classification="not classified",
+        )
+    ]
+
+    assert p[i].get_regressions("label") == {"test-failure": 0}
+    assert p[i + 1].get_regressions("label") == {}
+    assert p[i + 2].get_regressions("label") == {}
+
+
+def test_failure_not_on_push_keeps_happening_on_backout(monkeypatch, create_pushes):
+    """
+    Tests the scenario where a task succeeded in a parent push, didn't run in the
+    push of interest and failed in a push after the push of interest, but kept failing
+    on the backout of the push of interest.
+    """
+    p = create_pushes(4)
+    i = 1  # the index of the push we are mainly interested in
+
+    p[i - 1].tasks = [Task.create(id="1", label="test-failure", result="success")]
+    p[i].tasks = []
+    p[i].backedoutby = p[i + 2].rev
+    p[i + 1].tasks = [
+        Task.create(
+            id="1",
+            label="test-failure",
+            result="testfailed",
+            classification="not classified",
+        )
+    ]
+    p[i + 2].tasks = [
+        Task.create(
+            id="1",
+            label="test-failure",
+            result="testfailed",
+            classification="not classified",
+        )
+    ]
+
+    assert p[i].get_regressions("label") == {"test-failure": 2}
+    assert p[i + 1].get_regressions("label") == {"test-failure": 2}
+    assert p[i + 2].get_regressions("label") == {}
+
+
+def test_failure_not_on_push_keeps_happening_after_backout(monkeypatch, create_pushes):
+    """
+    Tests the scenario where a task succeeded in a parent push, didn't run in the
+    push of interest and failed in a push after the push of interest, but kept failing
+    after the backout of the push of interest.
+    """
+    p = create_pushes(7)
+    i = 1  # the index of the push we are mainly interested in
+
+    p[i - 1].tasks = [Task.create(id="1", label="test-failure", result="success")]
+    p[i].tasks = []
+    p[i].backedoutby = p[i + 3].rev
+    p[i + 1].tasks = []
+    p[i + 2].tasks = [
+        Task.create(
+            id="1",
+            label="test-failure",
+            result="testfailed",
+            classification="not classified",
+        )
+    ]
+    p[i + 5].tasks = [
+        Task.create(
+            id="1",
+            label="test-failure",
+            result="testfailed",
+            classification="not classified",
+        )
+    ]
+
+    assert p[i].get_regressions("label") == {"test-failure": 2}
+    assert p[i + 1].get_regressions("label") == {"test-failure": 4}
+    assert p[i + 2].get_regressions("label") == {"test-failure": 4}
+    assert p[i + 3].get_regressions("label") == {}
+
+
 def test_succeeded_and_backedout(create_pushes):
     """
     Tests the scenario where a task succeeded in a push which was backed-out.


### PR DESCRIPTION
Fixes #104

A few observations:
- I'm not sure exactly what kind of penalization we should use. Similarly with the other penalizations, they have mostly been chosen without measurement. Possibly we should find a way to measure their effectiveness. Maybe we should build a "ground truth" dataset on which we can measure improvements.
- This works better at the group-level, since it's less likely that two pushes which are close together both introduced a regression in the same group. At the task-level, instead, the probability is higher. Maybe even when getting regressions at the task-level, we should consider the underlying groups to check if two failures are the same. Or, we can just ignore it since at some point we'll be group-level completely.