### PR TITLE
Improve the way we handle 'fixed by commit' classifications

### DIFF
--- a/mozci/push.py
+++ b/mozci/push.py
@@ -376,7 +376,7 @@ class Push:
 
         return int(duration / 3600)
 
-    def _check_classification(self, other, classifications):
+    def _is_classified_as_cause(self, other, classifications):
         """Checks a 'fixed by commit' classification to figure out what push it references.
 
         Returns:
@@ -494,12 +494,12 @@ class Push:
                     passing_runnables.add(name)
                     continue
 
-                classification = self._check_classification(
+                is_classified_as_cause = self._is_classified_as_cause(
                     other, summary.classifications
                 )
-                if classification is True:
+                if is_classified_as_cause is True:
                     candidate_regressions[name] = (-math.inf, summary.status)
-                elif classification is False:
+                elif is_classified_as_cause is False:
                     passing_runnables.add(name)
                     continue
 

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -376,7 +376,7 @@ class Push:
 
         return int(duration / 3600)
 
-    def _check_classification(self, failure_push, classifications):
+    def _check_classification(self, other, classifications):
         """Checks a 'fixed by commit' classification to figure out what push it references.
 
         Returns:
@@ -417,7 +417,7 @@ class Push:
                 fix_hgmo = HGMO.create(classification_note, branch=self.branch)
             except PushNotFound:
                 logger.warning(
-                    "Classification note ({classification_note}) references a revision which does not exist on push {failure_push.rev}"
+                    "Classification note ({classification_note}) references a revision which does not exist on push {other.rev}"
                 )
                 return None
             if len(fix_hgmo.backouts) == 0:
@@ -445,7 +445,7 @@ class Push:
                     continue
 
                 if any(
-                    HGMO.create(backedout, branch=self.branch).pushid <= failure_push.id
+                    HGMO.create(backedout, branch=self.branch).pushid <= other.id
                     for backedout in backedouts
                 ):
                     return False

--- a/mozci/util/hgmo.py
+++ b/mozci/util/hgmo.py
@@ -66,5 +66,13 @@ class HGMO:
         return self._get_resource(url)["pushes"]
 
     @property
-    def is_backout(self):
-        return len(self.changesets[0]["backsoutnodes"]) > 0
+    def pushid(self):
+        return self.changesets[0]["pushid"]
+
+    @property
+    def backouts(self):
+        return {
+            changeset["node"]: [node["node"] for node in changeset["backsoutnodes"]]
+            for changeset in self.changesets
+            if len(changeset["backsoutnodes"])
+        }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ def responses():
 
 
 @pytest.fixture
-def create_push(responses):
+def create_push(monkeypatch, responses):
     """Returns a factory method that creates a `Push` instance.
 
     Each subsequent call to the factory will set the previously created
@@ -22,6 +22,13 @@ def create_push(responses):
 
     prev_push = None
     push_id = 1
+
+    push_rev_to_id = {}
+
+    def mock_pushid(cls):
+        return push_rev_to_id[cls.context["rev"]]
+
+    monkeypatch.setattr(HGMO, "pushid", property(mock_pushid))
 
     def inner(
         rev=None, branch="integration/autoland", json=None, automationrelevance=None
@@ -53,6 +60,7 @@ def create_push(responses):
 
         push = Push(rev, branch)
         push._id = push_id
+        push_rev_to_id[rev] = push_id
         push.backedoutby = None
         push.tasks = []
         push._revs = [push.rev]


### PR DESCRIPTION
In particular, ignore classifications which are clearly wrong.
Fixes #118