### PR TITLE
Use short changeset for caching HGMO instances

### DIFF
--- a/mozci/util/hgmo.py
+++ b/mozci/util/hgmo.py
@@ -26,7 +26,7 @@ class HGMO:
 
     @staticmethod
     def create(rev, branch="autoland"):
-        key = (branch, rev)
+        key = (branch, rev[:12])
         if key in HGMO.CACHE:
             return HGMO.CACHE[key]
         instance = HGMO(rev, branch)


### PR DESCRIPTION
This way we don't create two different instances when calling the function
once with a long changeset and once with its short version.