### PR TITLE
Refactor bustage_fixed_by and get_candidate_regressions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 import pytest
 from responses import RequestsMock
 
-from mozci.push import Push
+from mozci.push import MAX_DEPTH, Push
 from mozci.util.hgmo import HGMO
 
 
@@ -86,17 +86,18 @@ def create_pushes(create_push):
 
     def inner(num):
         pushes = []
+
+        # Create parents.
+        for j in range(MAX_DEPTH + 1):
+            create_push()
+
+        # Create our pushes.
         for i in range(num):
-            if i == 0:
-                pushes.append(create_push("first"))
-                pushes[0].parent = pushes[0]
+            pushes.append(create_push())
 
-            elif i == num - 1:
-                pushes.append(create_push("last"))
-                pushes[-1].child = pushes[-1]
-
-            else:
-                pushes.append(create_push())
+        # Create children.
+        for j in range(MAX_DEPTH + 1):
+            create_push()
 
         return pushes
 


### PR DESCRIPTION
To avoid dependencies between them, and factor out the duplicated code to iterate children.