### PR TITLE
Add an API to generate all shadow scheduler results

### DIFF
--- a/mozci/errors.py
+++ b/mozci/errors.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
 
+# push exceptions
+
+
 class BasePushException(Exception):
     def __init__(self, rev, branch, msg):
         self.rev = rev
@@ -32,6 +35,9 @@ class ParentPushNotFound(BasePushException):
         super(ParentPushNotFound, self).__init__(*args, **kwargs)
 
 
+# task exceptions
+
+
 class BaseTaskException(Exception):
     def __init__(self, id, label, msg):
         self.id = id
@@ -46,3 +52,11 @@ class ArtifactNotFound(BaseTaskException):
         kwargs["msg"] = f"artifact '{artifact}' does not exist!"
         self.artifact = artifact
         super(ArtifactNotFound, self).__init__(*args, **kwargs)
+
+
+class TaskNotFound(BaseTaskException):
+    """Raised when a Task id or index could not be found."""
+
+    def __init__(self, *args, **kwargs):
+        kwargs["msg"] = "task not found!"
+        super(TaskNotFound, self).__init__(*args, **kwargs)

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -13,7 +13,6 @@ from loguru import logger
 from mozci.errors import ChildPushNotFound, ParentPushNotFound, PushNotFound
 from mozci.task import GroupResult, GroupSummary, LabelSummary, Status, Task, TestTask
 from mozci.util.hgmo import HGMO
-from mozci.util.taskcluster import find_task_id
 
 BASE_INDEX = "gecko.v2.{branch}.revision.{rev}"
 
@@ -226,8 +225,7 @@ class Push:
             Task: A `Task` instance representing the decision task.
         """
         index = self.index + ".taskgraph.decision"
-        task_id = find_task_id(index)
-        return Task(id=task_id)
+        return Task.create(index=index)
 
     @memoized_property
     def tasks(self):
@@ -760,7 +758,7 @@ class Push:
             list: All task labels that would have been scheduled.
         """
         index = self.index + ".source.shadow-scheduler-{}".format(name)
-        task = Task(id=find_task_id(index))
+        task = Task.create(index=index)
         labels = task.get_artifact("public/shadow-scheduler/optimized_tasks.list")
         return set(labels.splitlines())
 

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -755,12 +755,28 @@ class Push:
             name (str): The name of the shadow scheduler to query.
 
         Returns:
-            list: All task labels that would have been scheduled.
+            set: All task labels that would have been scheduled.
         """
         index = self.index + ".source.shadow-scheduler-{}".format(name)
         task = Task.create(index=index)
         labels = task.get_artifact("public/shadow-scheduler/optimized_tasks.list")
         return set(labels.splitlines())
+
+    def generate_all_shadow_scheduler_tasks(self):
+        """Generates all tasks from all of the shadow schedulers that ran on the push.
+
+        Yields:
+            tuple: Of the form (<name>, [<label>]) where the first value is the
+            name of the shadow scheduler and the second is the set of tasks it
+            would have scheduled.
+        """
+        names = [
+            label.split("shadow-scheduler-")[1]
+            for label in self.scheduled_task_labels
+            if "shadow-scheduler" in label
+        ]
+        for name in sorted(names):
+            yield name, self.get_shadow_scheduler_tasks(name)
 
     def __repr__(self):
         return f"{super(Push, self).__repr__()} rev='{self.rev}'"

--- a/mozci/util/taskcluster.py
+++ b/mozci/util/taskcluster.py
@@ -88,10 +88,5 @@ def get_index_url(index_path):
 
 
 def find_task_id(index_path, use_proxy=False):
-    try:
-        response = _do_request(get_index_url(index_path))
-    except requests.exceptions.HTTPError as e:
-        if e.response.status_code == 404:
-            raise KeyError("index path {} not found".format(index_path))
-        raise
+    response = _do_request(get_index_url(index_path))
     return response.json()["taskId"]


### PR DESCRIPTION
Implements ``Push.generate_all_shadow_scheduler_tasks()``.