### PR TITLE
Raise exception if ADR_CONFIG_PATH env variable is not set for integration tests

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -11,6 +11,9 @@ pytestmark = pytest.mark.skipif(
     os.environ.get("TRAVIS_EVENT_TYPE") != "cron", reason="Not run by a cron task"
 )
 
+if not os.environ.get("ADR_CONFIG_PATH"):
+    raise Exception("Set ADR_CONFIG_PATH to tests/config.toml")
+
 
 def test_missing_manifests():
     """


### PR DESCRIPTION
When running pytest against the integration we need to set ADR_CONFIG as a variable.
tox was setting the ADR_CONFIG variable, however, this would not help if we are running pytest directly. This change configures pytest with the variable.