### PR TITLE
Cache tasks' errors/results grouped as a push

### DIFF
--- a/mozci/push.py
+++ b/mozci/push.py
@@ -318,6 +318,7 @@ class Push:
         # Normalize and validate.
         normalized_tasks = []
         for task in tasks.values():
+            task["push_uuid"] = self.push_uuid
             missing = [k for k in required_keys if k not in task]
             taskstr = task.get("label", task["id"])
 

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -311,8 +311,8 @@ class Push:
         # Normalize and validate.
         normalized_tasks = []
         for task in tasks.values():
-            # We pass the rev as part of the task to grouping them when caching them
-            task["rev"] = self.rev
+            # We pass the branch/rev as part of the task to grouping them when caching them
+            task["push_uuid"] = "{}-{}".format(self.branch, self.rev)
             missing = [k for k in required_keys if k not in task]
             taskstr = task.get("label", task["id"])
 

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -308,7 +308,7 @@ class Push:
             except MissingDataError:
                 pass
 
-        tasks = self._normalized_tasks(tasks)
+        tasks = Push._normalized_tasks(tasks)
 
         # Add any data available in the cache
         if was_cached:
@@ -329,7 +329,8 @@ class Push:
         # Let's gather any new data missing
         return self.gather_missing_results(tasks)
 
-    def _normalized_tasks(self, tasks):
+    @staticmethod
+    def _normalized_tasks(tasks):
         # If we are missing one of these keys, discard the task.
         required_keys = (
             "id",

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -372,18 +372,19 @@ class Push:
                         "results": t._results,
                     }
 
-            # Cache data
-            logger.debug(
-                "Storing test task error summaries for {} in the cache".format(
-                    self.push_uuid
-                )
-            )
             if push_tasks:
+                # Cache data
+                logger.debug(
+                    "Storing test task error summaries for {} in the cache".format(
+                        self.push_uuid
+                    )
+                )
                 # We *only* cache errors and results
                 # cachy's put() overwrites the value in the cache; add() would only add if its empty
                 adr.config.cache.put(
                     self.push_uuid, push_tasks, adr.config["cache"]["retention"],
                 )
+
             if adr.config.cache.get(self.push_uuid) is None:
                 logger.warning("The cache has failed to store.")
 

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -385,14 +385,8 @@ class Push:
             if isinstance(task, TestTask)
         }
 
-        # XXX: Using threading even for tasks that have data in AD can be slow. This push we're testing
-        # has more than 95% of all tasks in AD. If in test_integration you comment out lines 26 and
-        # lines 165-167 you will see that it takes 4 seconds with caching (it was almost instant in the previous iteration)
-        # and 6 seconds when there's no caching (This means fetching the TC data takes 2 seconds; about 70 tasks).
-        # I'm simply calling out FYI but I think it is fine
         for future in concurrent.futures.as_completed(future_to_task):
-            task = future_to_task[future]
-            logger.debug("Fetching errorsummary for {}".format(task.id))
+            future_to_task[future]
 
         return tasks
 

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -5,7 +5,6 @@ from argparse import Namespace
 from collections import defaultdict
 from functools import lru_cache
 
-import adr
 from adr.errors import MissingDataError
 from adr.query import run_query
 from adr.util.memoize import memoized_property
@@ -237,13 +236,6 @@ class Push:
         Returns:
             list: A list of `Task` objects.
         """
-        # XXX: When should we invalidate the data?
-        data = adr.config.cache.get(self.rev)
-        if data is not None:
-            logger.debug(
-                "Tasks for push {} were loaded from the cache.".format(self.rev)
-            )
-            return data
 
         args = Namespace(rev=self.rev, branch=self.branch)
         tasks = defaultdict(dict)
@@ -319,6 +311,8 @@ class Push:
         # Normalize and validate.
         normalized_tasks = []
         for task in tasks.values():
+            # We pass the rev as part of the task to grouping them when caching them
+            task["rev"] = self.rev
             missing = [k for k in required_keys if k not in task]
             taskstr = task.get("label", task["id"])
 
@@ -349,13 +343,6 @@ class Push:
 
             normalized_tasks.append(task)
 
-        # Only cache data if there's something to store
-        if normalized_tasks:
-            logger.debug("Storing push {} in the cache".format(self.rev))
-            # cachy's put() overwrites the value in the cache; add() would only add if its empty
-            adr.config.cache.put(
-                self.rev, normalized_tasks, adr.config["cache"]["retention"],
-            )
         return [Task.create(**task) for task in normalized_tasks]
 
     @property

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -318,7 +318,6 @@ class Push:
         # Normalize and validate.
         normalized_tasks = []
         for task in tasks.values():
-            task["push_uuid"] = self.push_uuid
             missing = [k for k in required_keys if k not in task]
             taskstr = task.get("label", task["id"])
 

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -366,7 +366,8 @@ class Push:
             future_to_task = {
                 Push.THREAD_POOL_EXECUTOR.submit(lambda task: task.groups, task): task
                 for task in tasks
-                if isinstance(task, TestTask)
+                # If AD already initialized the _groups field we don't need to cache that data
+                if isinstance(task, TestTask) and task._groups is None
             }
 
             for future in concurrent.futures.as_completed(future_to_task):

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -374,7 +374,6 @@ class Push:
                     else:
                         tasks_missing_results.append(t)
 
-            # fromAD = len(test_tasks.keys())
             logger.info(
                 "Stored {} errors/results from AD".format(len(test_tasks.keys()))
             )
@@ -386,9 +385,6 @@ class Push:
             future_to_task = {
                 Push.THREAD_POOL_EXECUTOR.submit(lambda task: task.results, task): task
                 for task in tasks_missing_results
-                # The 2nd condition in here is the opposite of the for/loop above to collect
-                # data from tasks queried via AD
-                # if isinstance(task, TestTask)
             }
 
             for future in concurrent.futures.as_completed(future_to_task):

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -382,15 +382,15 @@ class Push:
                 # The 2nd condition in here is the opposite of the for/loop above to collect
                 # data from tasks queried via AD
                 # XXX: On a following pass we will determine how bad processing errors can be
-                if isinstance(task, TestTask)
-                and (task._results is None)  # or task._errors is None)
+                # if isinstance(task, TestTask) and (task._results is None or task._errors is None)
+                if isinstance(task, TestTask) and (task._results is None)
             }
 
             for future in concurrent.futures.as_completed(future_to_task):
                 task = future_to_task[future]
                 # XXX: It would be ideal that loguru's debug would work
                 # XXX: Remove this? It's useful to let the user know that something is happening
-                logger.info("Processing {} {}".format(task.id, task._results))
+                logger.debug("Processing {} {}".format(task.id, task._results))
                 # We assert that the information was not gathered via AD already
                 assert push_tasks.get(task.id) is None
                 # This test task now has the values for errors, groups & results
@@ -418,7 +418,7 @@ class Push:
                 )
 
             if adr.config.cache.get(self.push_uuid) is None:
-                logger.warning("The cache has failed to store.")
+                logger.warning("The cache has failed to store the data.")
 
         return tasks
 

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -349,7 +349,7 @@ class Push:
         return tasks
 
     def fetch_errors_results(self, tasks: list) -> list:
-        """ If missing this function adds & caches errors and results to TestTasks"""
+        """ Fetch errors and results for test tasks. Define ADR_CONFIG_PATH and adr.cache for the caching to work"""
         test_tasks = adr.config.cache.get(self.push_uuid, {})
         if len(test_tasks.keys()) > 0:
             # Let's add cached error summaries to TestTasks
@@ -407,7 +407,6 @@ class Push:
                     len(tasks_missing_results)
                 )
             )
-
             if test_tasks:
                 # Cache data
                 logger.debug(

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -364,7 +364,9 @@ class Push:
             # Let's gather all collected data from AD
             for t in tasks:
                 # XXX: On a following pass we will determine how bad processing errors can be
-                if isinstance(t, TestTask) and t._results:  # and t._errors:
+                if isinstance(t, TestTask) and not (
+                    t._results is None
+                ):  # and t._errors:
                     push_tasks[t.id] = {
                         # "errors": t._errors,
                         "results": t._results,

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -361,33 +361,16 @@ class Push:
                     t._results = error_summary["results"]
             logger.info("Fetched tasks for {} from the cache".format(self.push_uuid))
         else:
-            # Let's gather the collected data via AD so we can cache it
+            # Let's gather all collected data
             for t in tasks:
-                if isinstance(t, TestTask) and t._results:
+                if isinstance(t, TestTask):
+                    if not t._results:
+                        # This will gather the data from Taskcluster
+                        t.results
                     push_tasks[t.id] = {
                         "errors": t._errors,
                         "results": t._results,
                     }
-
-            # If there are any test tasks that do not have results from AD let's fetch them
-            # If task.results is not initialized it will be fetched via Taskcluster
-            # Calling task.results modifies the properties of the task, thus, the returning list
-            # of this function comes back modified
-            future_to_task = {
-                Push.THREAD_POOL_EXECUTOR.submit(lambda task: task.results, task): task
-                for task in tasks
-                if isinstance(task, TestTask) and task._results is None
-            }
-
-            for future in concurrent.futures.as_completed(future_to_task):
-                task = future_to_task[future]
-                # We assert that the information was not gathered via AD already
-                assert push_tasks.get(task.id) is None
-                # This test task now has the values for errors, groups & results
-                push_tasks[task.id] = {
-                    "errors": task._errors or [],
-                    "results": task._results or [],
-                }
 
             # Cache data
             logger.debug(
@@ -395,11 +378,12 @@ class Push:
                     self.push_uuid
                 )
             )
-            # We *only* cache errors and results
-            # cachy's put() overwrites the value in the cache; add() would only add if its empty
-            adr.config.cache.put(
-                self.push_uuid, push_tasks, adr.config["cache"]["retention"],
-            )
+            if push_tasks:
+                # We *only* cache errors and results
+                # cachy's put() overwrites the value in the cache; add() would only add if its empty
+                adr.config.cache.put(
+                    self.push_uuid, push_tasks, adr.config["cache"]["retention"],
+                )
             if adr.config.cache.get(self.push_uuid) is None:
                 logger.warning("The cache has failed to store.")
 

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -7,6 +7,7 @@ from enum import Enum
 from inspect import signature
 from typing import Dict, List, Optional
 
+import adr
 import requests
 from adr.util import memoized_property
 from loguru import logger
@@ -111,6 +112,7 @@ class Task:
     classification: Optional[str] = field(default=None)
     classification_note: Optional[str] = field(default=None)
     tags: Dict = field(default_factory=dict)
+    rev: str = field(default=None)
 
     @staticmethod
     def create(index=None, **kwargs):
@@ -239,6 +241,14 @@ class TestTask(Task):
             result.group = result.group.replace("\\", "/")
 
     def _load_errorsummary(self):
+        # XXX: When should we invalidate the data?
+        push_data = adr.config.cache.get(self.rev)
+        # If there's data for the push and if it contains this task
+        if push_data and push_data.get(self.id):
+            self._errors = push_data[self.id]["errors"]
+            self._groups = push_data[self.id]["groups"]
+            self._results = push_data[self.id]["results"]
+            return None
         # This may clobber the values that were populated by ActiveData, but
         # since the artifact is already downloaded, parsed and we need to
         # iterate over it anyway. It doesn't really hurt and simplifies some
@@ -276,6 +286,20 @@ class TestTask(Task):
         ]
 
         self.__post_init__()
+        # Cache data
+        logger.debug("Storing {}/{} in the cache".format(self.rev, self.id))
+        # XXX: I have a slight concern of having a race condition if there are two different
+        # tasks calling _load_error_summary()
+        push_data = adr.config.cache.get(self.rev, {})
+        push_data[self.id] = {
+            "errors": self._errors,
+            "groups": self._groups,
+            "results": self._results,
+        }
+        # cachy's put() overwrites the value in the cache; add() would only add if its empty
+        adr.config.cache.put(
+            self.rev, push_data, adr.config["cache"]["retention"],
+        )
 
     @property
     def groups(self):

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -7,7 +7,6 @@ from enum import Enum
 from inspect import signature
 from typing import Dict, List, Optional
 
-import adr
 import requests
 from adr.util import memoized_property
 from loguru import logger
@@ -112,7 +111,6 @@ class Task:
     classification: Optional[str] = field(default=None)
     classification_note: Optional[str] = field(default=None)
     tags: Dict = field(default_factory=dict)
-    push_uuid: str = field(default=None)
 
     @staticmethod
     def create(index=None, **kwargs):
@@ -241,11 +239,6 @@ class TestTask(Task):
             result.group = result.group.replace("\\", "/")
 
     def _load_errorsummary(self):
-        push_data = adr.config.cache.get(self.push_uuid, {})
-        if push_data.get(self.id):
-            self._errors = push_data[self.id]._errors
-            self._groups = push_data[self.id]._groups
-            self._results = push_data[self.id]._results
         # This may clobber the values that were populated by ActiveData, but
         # since the artifact is already downloaded, parsed and we need to
         # iterate over it anyway. It doesn't really hurt and simplifies some
@@ -283,18 +276,6 @@ class TestTask(Task):
         ]
 
         self.__post_init__()
-        # Cache data
-        logger.debug("Storing {}-{} in the cache".format(self.push_uuid, self.id))
-        # XXX: I have a slight concern of having a race condition trying to write push data for the same uuid
-        push_data = adr.config.cache.get(self.push_uuid, {})
-        push_data[self.id]._errors = self._errors
-        push_data[self.id]._groups = self._groups
-        push_data[self.id]._results = self._results
-
-        # cachy's put() overwrites the value in the cache; add() would only add if its empty
-        adr.config.cache.put(
-            self.push_uuid, push_data, adr.config["cache"]["retention"],
-        )
 
     @property
     def groups(self):

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -279,19 +279,19 @@ class TestTask(Task):
 
     @property
     def groups(self):
-        if self._results is None:
+        if not self._results:
             self._load_errorsummary()
         return [result.group for result in self.results]
 
     @property
     def results(self):
-        if self._results is None:
+        if not self._results:
             self._load_errorsummary()
         return self._results
 
     @property
     def errors(self):
-        if self._errors is None:
+        if not self._errors:
             self._load_errorsummary()
         return self._errors
 

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -279,19 +279,19 @@ class TestTask(Task):
 
     @property
     def groups(self):
-        if not self._results:
+        if self._results is None:
             self._load_errorsummary()
         return [result.group for result in self.results]
 
     @property
     def results(self):
-        if not self._results:
+        if self._results is None:
             self._load_errorsummary()
         return self._results
 
     @property
     def errors(self):
-        if not self._errors:
+        if self._errors is None:
             self._load_errorsummary()
         return self._errors
 

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -239,13 +239,6 @@ class TestTask(Task):
             result.group = result.group.replace("\\", "/")
 
     def _load_errorsummary(self):
-        # XXX: How or where should we invalidate the data?
-        # Temporarily disable caching as it's creating too many entries.
-        data = None  # adr.config.cache.get(self.id)
-        if data:
-            self._errors = data["errors"]
-            self._results = data["results"]
-            return None
         # This may clobber the values that were populated by ActiveData, but
         # since the artifact is already downloaded, parsed and we need to
         # iterate over it anyway. It doesn't really hurt and simplifies some
@@ -283,19 +276,6 @@ class TestTask(Task):
         ]
 
         self.__post_init__()
-        # Only store data if there's something to store
-        if self._errors or self._results:
-            logger.debug("Storing {} in the cache".format(self.id))
-            # cachy's put() overwrites the value in the cache; add() would only add if its empty
-            # Temporarily disable caching as it's creating too many entries.
-            # adr.config.cache.put(
-            #     self.id,
-            #     {
-            #         "errors": self._errors,
-            #         "results": self._results,
-            #     },
-            #     adr.config["cache"]["retention"],
-            # )
 
     @property
     def groups(self):

--- a/tests/config.toml
+++ b/tests/config.toml
@@ -1,8 +1,2 @@
 [adr]
 sources = ["tests"]
-verbose = true
-[adr.cache]
-default = "file"
-retention = 1000
-[adr.cache.stores]
-file = { driver = "file", path = "/Users/armenzg/repos/mozci/adr_cache" }

--- a/tests/config.toml
+++ b/tests/config.toml
@@ -1,2 +1,8 @@
 [adr]
 sources = ["tests"]
+verbose = 1
+[adr.cache]
+default = "file"
+retention = 1000
+[adr.cache.stores]
+file = { driver = "file", path = "adr_tests_cache" }

--- a/tests/config.toml
+++ b/tests/config.toml
@@ -1,2 +1,8 @@
 [adr]
 sources = ["tests"]
+verbose = true
+[adr.cache]
+default = "file"
+retention = 1000
+[adr.cache.stores]
+file = { driver = "file", path = "/Users/armenzg/repos/mozci/adr_cache" }

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -172,7 +172,7 @@ def test_caching_of_push(cache):
     if cache.get(PUSH_UUID):
         cache.forget(PUSH_UUID)
     assert cache.get(PUSH_UUID) is None
-    # Only use pushes older than 6 weeks (AD's unittest retention data)
+
     push = Push(REV, branch=BRANCH)
     # Q: Calling push.tasks a second time would hit the cache; Should we test that scenario?
     tasks = push.tasks

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -171,6 +171,18 @@ def test_good_result_manifests():
         ), f"{group} group for task {label} is bad!"
 
 
+def test_caching_issue(adr_config):
+    from mozci.task import GroupResult
+
+    a = GroupResult(
+        group="testing/marionette/harness/marionette_harness/tests/unit-tests.ini",
+        ok=True,
+    )
+    adr_config.cache.put("foo", a, 5)
+    print(adr_config.get("foo"))
+    assert adr_config.get("foo")
+
+
 def test_caching_of_push(adr_config):
     # A push if it's very recent, it will have almost no tasks in AD
     # few days later all data will come from AD and after 6 weeks it will have no data there.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -21,12 +21,17 @@ if not os.environ.get("ADR_CONFIG_PATH"):
 
 @pytest.fixture
 def cache():
+    # The directory is defined in tests/config.toml
+    # If you want to iterate fast on tests that use the cache you can temporarily
+    # comment out the steps deleting the cache
+    cache_path = "adr_tests_cache"
     try:
+        if os.path.isdir(cache_path):
+            # Make sure we start from a clean slate
+            shutil.rmtree(cache_path)
         yield adr.config.cache
     finally:
-        # The directory is defined in tests/config.toml
-        # If you want to iterate on one of these tests you can temporarily comment this line
-        shutil.rmtree("adr_tests_cache")
+        shutil.rmtree(cache_path)
 
 
 def test_create_pushes_and_get_regressions():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -168,8 +168,8 @@ def test_caching_of_tasks(adr_config):
     # Once we reach Nov. 23rd, 2020 the test should be updated with a more recent push and task ID
     REV = "6e87f52e6eebdf777f975baa407d5c22e9756e80"
     PUSH_UUID = "mozilla-beta/{}".format(REV)
-    # TASK_1 = "Z-mKvs0jSaSkKLPFZeO3Qw"
-    # TASK_2 = "WGNh9Xd8RmSG_170-0-mkQ"
+    TASK_1 = "Z-mKvs0jSaSkKLPFZeO3Qw"
+    TASK_2 = "WGNh9Xd8RmSG_170-0-mkQ"
 
     # Making sure there's nothing left in the cache
     assert adr_config.cache.get(PUSH_UUID) is None
@@ -178,36 +178,27 @@ def test_caching_of_tasks(adr_config):
     # Testing that the tasks associated to a push have been cached
     assert len(adr_config.cache.get(PUSH_UUID).keys()) == len(tasks)
 
-    # XXX: We no cache all tasks; think this through
-    # cached_tasks = 0
+    validated_tasks = 0
+    for t in tasks:
+        if t.id == TASK_1:
+            # This will call _load_error_summary and cache the data
+            t.groups
+            validated_tasks += 1
 
-    # def validate_cache():
-    #     push_data = adr_config.cache.get(REV, {})
-    #     assert len(push_data.keys()) == cached_tasks
+        if t.id == TASK_2:
+            # This will call _load_errorsummary and cache the data
+            t.results
+            push_task_map = adr_config.cache.get(PUSH_UUID)
+            # Let's validate some data about the task
+            task = push_task_map[t.id]
+            assert not task.errors
+            assert task.groups.index("docshell/test/browser/browser.ini") > -1
+            assert not task.results
+            validated_tasks += 1
 
-    # for t in tasks:
-    #     if t.id == TASK_1:
-    #         # This will call _load_error_summary and cache the data
-    #         t.groups
-    #         cached_tasks += 1
-    #         validate_cache()
-
-    #     if t.id == TASK_2:
-    #         # This will call _load_error_summary and cache the data
-    #         t.results
-    #         push_task_map = adr_config.cache.get(REV)
-    #         # Let's validate some data about the task
-    #         task = push_task_map[t.id]
-    #         # We cache three properties (errors, groups, results) per task
-    #         assert len(task.keys()) == 3
-    #         assert not task["errors"]
-    #         assert task["groups"].index("docshell/test/browser/browser.ini") > -1
-    #         assert not task["results"]
-    #         cached_tasks += 1
-    #         validate_cache()
-
-    #     if cached_tasks == 2:
-    #         break
+        # So we don't iterate for ever
+        if validated_tasks == 2:
+            break
 
     # Q: Is it good practice to clean the test here?
     adr_config.cache.forget(REV)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -174,6 +174,7 @@ def test_caching_of_tasks(adr_config):
     # Making sure there's nothing left in the cache
     assert adr_config.cache.get(PUSH_UUID) is None
     push = Push(REV, branch="mozilla-beta")  # Push from Nov. 22nd, 2019
+    # Q: Calling push.tasks a second time would hit the cache; Should we test that scenario?
     tasks = push.tasks
     # Testing that the tasks associated to a push have been cached
     assert len(adr_config.cache.get(PUSH_UUID).keys()) == len(tasks)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -21,9 +21,12 @@ if not os.environ.get("ADR_CONFIG_PATH"):
 
 @pytest.fixture
 def cache():
-    yield adr.config.cache
-    # If you want to iterate on one of these tests you can temporarily comment this line
-    shutil.rmtree("adr_tests_cache")  # The directory is defined in tests/config.toml
+    try:
+        yield adr.config.cache
+    finally:
+        # The directory is defined in tests/config.toml
+        # If you want to iterate on one of these tests you can temporarily comment this line
+        shutil.rmtree("adr_tests_cache")
 
 
 def test_create_pushes_and_get_regressions():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -164,28 +164,30 @@ def test_good_result_manifests():
         ), f"{group} group for task {label} is bad!"
 
 
-def test_caching_of_tasks(adr_config):
-    return
-    # Once we reach Nov. 23rd, 2020 the test should be updtated with a more recent push and task ID
+def test_caching_of_push(adr_config):
+    # Once we reach Nov. 23rd, 2020 the test should be updated with a more recent push and task ID
     TASK_ID = "WGNh9Xd8RmSG_170-0-mkQ"
+    REV = "6e87f52e6eebdf777f975baa407d5c22e9756e80"
     # Making sure there's nothing left in the cache
-    assert adr_config.cache.get(TASK_ID) is None
+    assert adr_config.cache.get(REV) is None
     # Push from Nov. 22nd, 2019
-    push = Push("6e87f52e6eebdf777f975baa407d5c22e9756e80", branch="mozilla-beta")
+    push = Push(REV, branch="mozilla-beta")
     tasks = push.tasks
+
     found_task = False
     for t in tasks:
+        # We are just testing that the task was retrieved
         if t.id == TASK_ID:
-            task = adr_config.cache.get(TASK_ID)
-            assert task is None
-            # Calling one of the three properties will call _load_error_summary
-            # and cache the data
-            t.results
-            task = adr_config.cache.get(TASK_ID)
-            assert task["groups"]
-            assert not task["errors"]
-            assert not task["results"]
             found_task = True
             break
-
     assert found_task
+
+    # Testing that the tasks associated to a push have been cached
+    assert len(adr_config.cache.get(REV)) == 2166
+
+    # XXX: We could test here that a 2nd call hits the cache
+    push.tasks
+
+    # Q: Is it good practice to clean the test here?
+    adr_config.cache.forget(REV)
+    assert adr_config.cache.get(REV) is None

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -173,7 +173,8 @@ def test_caching_of_tasks(adr_config):
 
     # Making sure there's nothing left in the cache
     assert adr_config.cache.get(PUSH_UUID) is None
-    push = Push(REV, branch="mozilla-beta")  # Push from Nov. 22nd, 2019
+    # Push from Nov. 22nd, 2019. Only use pushes older than 6 weeks (AD's unittest retention data)
+    push = Push(REV, branch="mozilla-beta")
     # Q: Calling push.tasks a second time would hit the cache; Should we test that scenario?
     tasks = push.tasks
     # Testing that the tasks associated to a push have been cached

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -167,47 +167,47 @@ def test_good_result_manifests():
 def test_caching_of_tasks(adr_config):
     # Once we reach Nov. 23rd, 2020 the test should be updated with a more recent push and task ID
     REV = "6e87f52e6eebdf777f975baa407d5c22e9756e80"
-    TASK_1 = "Z-mKvs0jSaSkKLPFZeO3Qw"
-    TASK_2 = "WGNh9Xd8RmSG_170-0-mkQ"
+    PUSH_UUID = "mozilla-beta/{}".format(REV)
+    # TASK_1 = "Z-mKvs0jSaSkKLPFZeO3Qw"
+    # TASK_2 = "WGNh9Xd8RmSG_170-0-mkQ"
 
     # Making sure there's nothing left in the cache
-    assert adr_config.cache.get(REV) is None
+    assert adr_config.cache.get(PUSH_UUID) is None
     push = Push(REV, branch="mozilla-beta")  # Push from Nov. 22nd, 2019
     tasks = push.tasks
-    assert len(tasks) == 2166
-
-    cached_tasks = 0
-
-    def validate_cache():
-        push_data = adr_config.cache.get(REV, {})
-        assert len(push_data.keys()) == cached_tasks
-
-    for t in tasks:
-        if t.id == TASK_1:
-            # This will call _load_error_summary and cache the data
-            t.groups
-            cached_tasks += 1
-            validate_cache()
-
-        if t.id == TASK_2:
-            # This will call _load_error_summary and cache the data
-            t.results
-            push_task_map = adr_config.cache.get(REV)
-            # Let's validate some data about the task
-            task = push_task_map[t.id]
-            # We cache three properties (errors, groups, results) per task
-            assert len(task.keys()) == 3
-            assert not task["errors"]
-            assert task["groups"].index("docshell/test/browser/browser.ini") > -1
-            assert not task["results"]
-            cached_tasks += 1
-            validate_cache()
-
-        if cached_tasks == 2:
-            break
-
     # Testing that the tasks associated to a push have been cached
-    assert len(adr_config.cache.get(REV)) == 2
+    assert len(adr_config.cache.get(PUSH_UUID).keys()) == len(tasks)
+
+    # XXX: We no cache all tasks; think this through
+    # cached_tasks = 0
+
+    # def validate_cache():
+    #     push_data = adr_config.cache.get(REV, {})
+    #     assert len(push_data.keys()) == cached_tasks
+
+    # for t in tasks:
+    #     if t.id == TASK_1:
+    #         # This will call _load_error_summary and cache the data
+    #         t.groups
+    #         cached_tasks += 1
+    #         validate_cache()
+
+    #     if t.id == TASK_2:
+    #         # This will call _load_error_summary and cache the data
+    #         t.results
+    #         push_task_map = adr_config.cache.get(REV)
+    #         # Let's validate some data about the task
+    #         task = push_task_map[t.id]
+    #         # We cache three properties (errors, groups, results) per task
+    #         assert len(task.keys()) == 3
+    #         assert not task["errors"]
+    #         assert task["groups"].index("docshell/test/browser/browser.ini") > -1
+    #         assert not task["results"]
+    #         cached_tasks += 1
+    #         validate_cache()
+
+    #     if cached_tasks == 2:
+    #         break
 
     # Q: Is it good practice to clean the test here?
     adr_config.cache.forget(REV)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -173,12 +173,14 @@ def test_good_result_manifests():
 
 def test_caching_of_push(adr_config):
     # A push if it's very recent, it will have almost no tasks in AD
-    # few days later all data will come from AD
-    # and after 6 weeks it will have no data
-    # Data about the groups for a task will come via AD or through the errorsummary artifact
-    # Regardless of which source was used we store in the same cache
+    # few days later all data will come from AD and after 6 weeks it will have no data there.
+    # Data about the results for a task will come via AD or through the errorsummary artifact
+    # via Taskcluster. Regardless of which source was used we store in the same data
+    # in the cache
 
     # Once this push is older than a year update the revision
+    # Once this push is older than 6 weeks the test will run slower because
+    # all test tasks results will come from Taskcluster
     REV = "2fd61eb5c69ce9ac806048a35c7a7a88bf4b9652"  # Push from Apr. 21, 2020.
     BRANCH = "mozilla-central"
     PUSH_UUID = "{}/{}".format(BRANCH, REV)
@@ -210,7 +212,6 @@ def test_caching_of_push(adr_config):
                 assert push_task_map[t.id]
                 cached_test_tasks += 1
 
-        # This is only true if AD has non of the tasks
         assert cached_test_tasks == TOTAL_TEST_TASKS
     finally:
         # Make sure we forget the cached data

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -165,7 +165,7 @@ def test_good_result_manifests():
         ), f"{group} group for task {label} is bad!"
 
 
-def test_caching_of_tasks(adr_config):
+def test_caching_of_old_push(adr_config):
     # Once we reach Nov. 23rd, 2020 the test should be updated with a more recent push and task ID
     REV = "6e87f52e6eebdf777f975baa407d5c22e9756e80"
     PUSH_UUID = "mozilla-beta/{}".format(REV)
@@ -203,6 +203,39 @@ def test_caching_of_tasks(adr_config):
 
     assert test_tasks == TOTAL_TEST_TASKS
 
+    # Q: Is it good practice to clean the test here?
+    adr_config.cache.forget(PUSH_UUID)
+    assert adr_config.cache.get(PUSH_UUID) is None
+
+
+def test_caching_of_recent_push(adr_config):
+    # Only use pushes less than 6 weeks (AD's unittest retention data)
+    REV = "2fd61eb5c69ce9ac806048a35c7a7a88bf4b9652"
+    PUSH_UUID = "mozilla-central/{}".format(REV)
+    # Making sure there's nothing left in the cache
+    assert adr_config.cache.get(PUSH_UUID) is None
+    # Push from Apr. 21st
+    push = Push(REV, branch="mozilla-central")
+    # Q: Calling push.tasks a second time would hit the cache; Should we test that scenario?
+    tasks = push.tasks
+    push_task_map = adr_config.cache.get(PUSH_UUID)
+
+    test_tasks = 0
+    tasks_without_summary = 0
+    # No task should have been cached since all data should have been cached without hiting Taskcluster
+    for t in tasks:
+        if isinstance(t, TestTask):
+            test_tasks += 1
+
+        error_summary = push_task_map.get(t.id)
+        if error_summary:
+            print("{} {}".format(t.id, t.label))
+            tasks_without_summary += 1
+
+    print("Test tasks: {}".format(test_tasks))
+    print(
+        "Test tasks that we fetched its error summary: {}".format(tasks_without_summary)
+    )
     # Q: Is it good practice to clean the test here?
     adr_config.cache.forget(PUSH_UUID)
     assert adr_config.cache.get(PUSH_UUID) is None


### PR DESCRIPTION
Fixes #158

The original code to cache tasks was storing each task in a different cache key, which
makes the number of elements in the cache explode. We should instead cache all the tasks
of a push together.