### PR TITLE
Support getting regressions for groups at given configurations

### DIFF
--- a/mozci/push.py
+++ b/mozci/push.py
@@ -396,7 +396,7 @@ class Push:
                 yield task, group
 
     @memoized_property
-    def group_config_summaries(self):
+    def config_group_summaries(self):
         """All group summaries, on given configurations, combining retriggers.
 
         Returns:

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -22,6 +22,39 @@ class Status(Enum):
     INTERMITTENT = 2
 
 
+SUITES = (
+    "mochitest-plain-gpu",
+    "mochitest-plain",
+    "mochitest-chrome-gpu",
+    "mochitest-chrome",
+    "mochitest-devtools-chrome",
+    "mochitest-browser-chrome",
+    "web-platform-tests-wdspec",
+    "web-platform-tests",
+    "mochitest-media",
+    "mochitest-webgpu",
+    "mochitest-webgl1-ext",
+    "mochitest-webgl2-ext",
+    "mochitest-webgl1-core",
+    "mochitest-webgl2-core",
+    "mochitest-remote",
+    "mochitest-a11y",
+    "xpcshell",
+    "crashtest",
+    "reftest-no-accel",
+    "gtest",
+    "telemetry-tests-client",
+    "browser-screenshots",
+    "marionette-gpu",
+    "marionette",
+    "cppunit",
+    "firefox-ui-functional-remote",
+    "firefox-ui-functional-local",
+    "reftest",
+    "junit",
+)
+
+
 NO_GROUPS_SUITES = (
     "raptor",
     "talos",
@@ -266,38 +299,6 @@ class TestTask(Task):
 
     @property
     def configuration(self):
-        SUITES = (
-            "mochitest-plain-gpu",
-            "mochitest-plain",
-            "mochitest-chrome-gpu",
-            "mochitest-chrome",
-            "mochitest-devtools-chrome",
-            "mochitest-browser-chrome",
-            "web-platform-tests-wdspec",
-            "web-platform-tests",
-            "mochitest-media",
-            "mochitest-webgpu",
-            "mochitest-webgl1-ext",
-            "mochitest-webgl2-ext",
-            "mochitest-webgl1-core",
-            "mochitest-webgl2-core",
-            "mochitest-remote",
-            "mochitest-a11y",
-            "xpcshell",
-            "crashtest",
-            "reftest-no-accel",
-            "gtest",
-            "telemetry-tests-client",
-            "browser-screenshots",
-            "marionette-gpu",
-            "marionette",
-            "cppunit",
-            "firefox-ui-functional-remote",
-            "firefox-ui-functional-local",
-            "reftest",
-            "junit",
-        )
-
         # Remove the suite name.
         config = self.label
         for s in SUITES:

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -298,16 +298,15 @@ class TestTask(Task):
             "junit",
         )
 
+        # Remove the suite name.
         config = self.label
         for s in SUITES:
             if f"-{s}-" in config:
                 config = config.replace(s, "*")
 
-        parts = config.split("/")
-
-        return "{}/{}".format(
-            parts[0], "-".join(p for p in parts[1].split("-") if not p.isdigit())
-        )
+        # Remove the chunk number.
+        parts = config.split("-")
+        return "-".join(parts[:-1] if parts[-1].isdigit() else parts)
 
 
 @dataclass

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -264,6 +264,51 @@ class TestTask(Task):
             self._load_errorsummary()
         return self._errors
 
+    @property
+    def configuration(self):
+        SUITES = (
+            "mochitest-plain-gpu",
+            "mochitest-plain",
+            "mochitest-chrome-gpu",
+            "mochitest-chrome",
+            "mochitest-devtools-chrome",
+            "mochitest-browser-chrome",
+            "web-platform-tests-wdspec",
+            "web-platform-tests",
+            "mochitest-media",
+            "mochitest-webgpu",
+            "mochitest-webgl1-ext",
+            "mochitest-webgl2-ext",
+            "mochitest-webgl1-core",
+            "mochitest-webgl2-core",
+            "mochitest-remote",
+            "mochitest-a11y",
+            "xpcshell",
+            "crashtest",
+            "reftest-no-accel",
+            "gtest",
+            "telemetry-tests-client",
+            "browser-screenshots",
+            "marionette-gpu",
+            "marionette",
+            "cppunit",
+            "firefox-ui-functional-remote",
+            "firefox-ui-functional-local",
+            "reftest",
+            "junit",
+        )
+
+        config = self.label
+        for s in SUITES:
+            if f"-{s}-" in config:
+                config = config.replace(s, "*")
+
+        parts = config.split("/")
+
+        return "{}/{}".format(
+            parts[0], "-".join(p for p in parts[1].split("-") if not p.isdigit())
+        )
+
 
 @dataclass
 class RunnableSummary(ABC):

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -79,3 +79,45 @@ def test_to_json():
     for k, v in kwargs.items():
         assert k in result
         assert result[k] == v
+
+
+def test_configuration():
+    assert (
+        Task.create(
+            id=1, label="test-windows7-32/debug-reftest-gpu-e10s-1"
+        ).configuration
+        == "test-windows7-32/debug-*-gpu-e10s"
+    )
+    assert (
+        Task.create(
+            id=1, label="test-linux1804-64/debug-mochitest-plain-gpu-e10s"
+        ).configuration
+        == "test-linux1804-64/debug-*-e10s"
+    )
+    assert (
+        Task.create(
+            id=1,
+            label="test-macosx1014-64-shippable/opt-web-platform-tests-wdspec-headless-e10s-1",
+        ).configuration
+        == "test-macosx1014-64-shippable/opt-*-headless-e10s"
+    )
+    assert (
+        Task.create(
+            id=1, label="test-linux1804-64-asan/opt-web-platform-tests-e10s-3"
+        ).configuration
+        == "test-linux1804-64-asan/opt-*-e10s"
+    )
+    assert (
+        Task.create(
+            id=1,
+            label="test-linux1804-64-qr/debug-web-platform-tests-wdspec-fis-e10s-1",
+        ).configuration
+        == "test-linux1804-64-qr/debug-*-fis-e10s"
+    )
+    assert (
+        Task.create(
+            id=1,
+            label="test-windows7-32-shippable/opt-firefox-ui-functional-remote-e10s",
+        ).configuration
+        == "test-windows7-32-shippable/opt-*-e10s"
+    )


### PR DESCRIPTION
Fixes #162

Example output for `Push("a2bff0eef797dc2f2f40779eb08ccfae0ceeb27f").get_regressions("group_config")`:
```
{
	('windows7-32', 'extensions/permissions/test/unit/xpcshell.ini'): 0,
	('macosx1014-64', 'extensions/permissions/test/unit/xpcshell.ini'): 0,
	('linux1804-64-shippable', 'extensions/permissions/test/unit/xpcshell.ini'): 0,
        ('linux1804-64-qr', 'extensions/permissions/test/unit/xpcshell.ini'): 0,
        ('macosx1014-64-shippable', 'extensions/permissions/test/unit/xpcshell.ini'): 0,
        ('windows10-64', 'extensions/permissions/test/unit/xpcshell.ini'): 0,
        ('linux1804-64', 'extensions/permissions/test/unit/xpcshell.ini'): 0,
        ('windows10-64-shippable', 'extensions/permissions/test/unit/xpcshell.ini'): 0,
        ('windows10-64-shippable', 'toolkit/components/extensions/test/xpcshell/xpcshell-common.ini'): 0, ('windows7-32-shippable', 'extensions/permissions/test/unit/xpcshell.ini'): 0,
        ('linux1804-64-asan', 'extensions/permissions/test/unit/xpcshell.ini'): 0,
        ('linux1804-64-shippable-qr', 'extensions/permissions/test/unit/xpcshell.ini'): 0,
        ('linux1804-64-tsan', 'extensions/permissions/test/unit/xpcshell.ini'): 0
}
```