### PR TITLE
Consider groups for which we have no `test_result` line in the errorsummary to be passing

### DIFF
--- a/mozci/push.py
+++ b/mozci/push.py
@@ -334,8 +334,6 @@ class Push:
                 if task.get("_result_group"):
                     groups = task.pop("_result_group")
 
-                    task["_groups"] = groups
-
                     task["_results"] = [
                         GroupResult(group=group, ok=ok)
                         for group, ok in zip(groups, oks)


### PR DESCRIPTION
Fixes #171

This also gets rid of the `_groups` property (making `groups` use `_results`), since it's redundant with `_results`.