### PR TITLE
Don't fail when an errorsummary.log doesn't contain a 'test_groups' action

### DIFF
--- a/mozci/task.py
+++ b/mozci/task.py
@@ -261,6 +261,8 @@ class TestTask(Task):
         except IndexError:
             return
 
+        groups = None
+
         lines = [json.loads(l) for l in self.get_artifact(path).splitlines()]
         for line in lines:
             if line["action"] == "test_groups":
@@ -278,13 +280,16 @@ class TestTask(Task):
             elif line["action"] == "log":
                 self._errors.append(line["message"])
 
-        # Assume all groups for which we have no results passed.
-        # In practice, they could also have been skipped (we should ignore them when
-        # it will be feasible, https://github.com/mozilla/mozci/issues/166).
-        known_results = {result.group for result in self._results}
-        self._results += [
-            GroupResult(group, True) for group in groups if group not in known_results
-        ]
+        if groups is not None:
+            # Assume all groups for which we have no results passed.
+            # In practice, they could also have been skipped (we should ignore them when
+            # it will be feasible, https://github.com/mozilla/mozci/issues/166).
+            known_results = {result.group for result in self._results}
+            self._results += [
+                GroupResult(group, True)
+                for group in groups
+                if group not in known_results
+            ]
 
         self.__post_init__()
 


### PR DESCRIPTION
E.g. Kh39_mBqRXO8bxTJJADYHg (test-linux1804-64-shippable-qr/opt-crashtest-e10s): [crashtest_errorsummary.log](https://github.com/mozilla/mozci/files/4643714/crashtest_errorsummary.log).