### PR TITLE
Add test-verify to the list of suites

### DIFF
--- a/mozci/task.py
+++ b/mozci/task.py
@@ -52,6 +52,7 @@ SUITES = (
     "firefox-ui-functional-local",
     "reftest",
     "junit",
+    "test-verify",
 )
 
 


### PR DESCRIPTION
Otherwise, test-verify tasks would be considered as a different configuration.