### PR TITLE
Use result.ok_intermittent instead of result.ok to ignore known intermittent failures

### DIFF
--- a/mozci/queries/push_tasks_results_from_unittest.query
+++ b/mozci/queries/push_tasks_results_from_unittest.query
@@ -3,7 +3,7 @@ groupby:
     - {name: id, value: task.id}
     - {name: _result_group, value: result.group}
 select:
-    - {name: _result_ok, value: result.ok, aggregate: min}
+    - {name: _result_ok, value: result.ok_intermittent, aggregate: min}
 where:
     and:
         - prefix: {repo.changeset.id: {$eval: rev}}


### PR DESCRIPTION
Fixes #226