### PR TITLE
Make sure to always remove _result_group when normalizing task objects

### DIFF
--- a/mozci/push.py
+++ b/mozci/push.py
@@ -367,11 +367,11 @@ class Push:
                 if isinstance(task["classification_note"], list):
                     task["classification_note"] = task["classification_note"][-1]
 
-            if task.get("_result_ok"):
-                oks = task.pop("_result_ok")
+            if task.get("_result_group"):
+                groups = task.pop("_result_group")
 
-                if task.get("_result_group"):
-                    groups = task.pop("_result_group")
+                if task.get("_result_ok"):
+                    oks = task.pop("_result_ok")
 
                     task["_results"] = [
                         GroupResult(group=group, ok=ok)


### PR DESCRIPTION
Since 846798e5b9db6e3a33dd58ba0b14d19b8585f5a1, there might be cases where we have _result_group and no _result_ok
(since the ok_intermittent value is not available yet in all unittest results).