### PR TITLE
Make sure to always remove _result_ok when normalizing task objects

### DIFF
--- a/mozci/push.py
+++ b/mozci/push.py
@@ -368,12 +368,11 @@ class Push:
                 if isinstance(task["classification_note"], list):
                     task["classification_note"] = task["classification_note"][-1]
 
-            if task.get("_result_group"):
-                groups = task.pop("_result_group")
+            groups = task.pop("_result_group", None)
+            oks = task.pop("_result_ok", None)
 
-                if task.get("_result_ok"):
-                    oks = task.pop("_result_ok")
-
+            if groups is not None:
+                if oks:
                     task["_results"] = [
                         GroupResult(group=group, ok=ok)
                         for group, ok in zip(groups, oks)


### PR DESCRIPTION
There are be cases where we have _result_ok and no _result_group, e.g. Talos

Fixes a regression from ab5fe1325ad5045d738c698e276b6283dc037f4b