### PR TITLE
#102 - Add overhead value to TestTask

### DIFF
--- a/mozci/queries/test_task_overhead.query
+++ b/mozci/queries/test_task_overhead.query
@@ -1,0 +1,11 @@
+from: unittest
+format: list
+groupby: task.id
+limit: 20000
+select:
+    - {value: action.start_time, name: task_min, aggregate: min}
+    - {value: action.end_time, name: task_max, aggregate: max}
+    - {value: result.start_time, name: group_min, aggregate: min}
+    - {value: result.end_time, name: group_max, aggregate: max}
+where:
+    - in: {task.id: {$eval: task_id}}

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -522,6 +522,18 @@ class LabelSummary(RunnableSummary):
     def median_duration(self):
         return median(self.durations)
 
+    @property
+    def overheads(self):
+        return [task.overhead for task in self.tasks]
+
+    @property
+    def total_overheads(self):
+        return sum(self.overheads)
+
+    @property
+    def median_overhead(self):
+        return median(self.overheads)
+
     @memoized_property
     def status(self):
         overall_status = None

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -377,8 +377,8 @@ class TestTask(Task):
         """
         data = run_query("test_task_overhead", Namespace(task_id=self.id))["data"].pop()
         # Sanity check to ensure group start/end times are within task start/end.
-        assert data["task_min"] < data["group_min"]
-        assert data["task_max"] > data["group_max"]
+        if data["task_min"] < data["group_min"] or data["task_max"] > data["group_max"]:
+            logger.warning(f"task f{self.id} has inconsistent group duration.")
 
         return (data["group_min"] - data["task_min"]) + (
             data["task_max"] - data["group_max"]

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -365,15 +365,15 @@ class TestTask(Task):
         """Calculate the overhead of a task.
 
         The methodology is simple: each task (action) has a start/end time.
-        Each group also has a start/end time. Take the earlist known group start
+        Each group also has a start/end time. Take the earliest known group start
         and latest known group end time, ensure the two falls somewhere in between
         task start/end.
 
-        Then calculate the overhead by taking the difference between the start
-        and end times.
+        This definition of overhead does not take into account inter-group overhead
+        eg. restarting browser, teardown, etc.
 
         Returns:
-            float: difference between task start/end and group star/end times.
+            float: difference between task start/end and group start/end times.
         """
         data = run_query("test_task_overhead", Namespace(task_id=self.id))["data"].pop()
         # Sanity check to ensure group start/end times are within task start/end.


### PR DESCRIPTION
This implements the TestTask.overhead property that returns a float value representing non-group time.

Example Usage:

```
>>> import mozci
>>> from mozci.push import Push
>>> push = Push('b32bf0e2fa08e29748da69ac64fbe41659ad372c', branch='autoland')
>>> task = push.tasks[3]
>>> task.overhead
447.7479989528656
```

Or..

```
>>> for label, overhead in [(task.label, task.overhead) for task in push.tasks if type(task) == TestTask]:
...     print(label, overhead)
...
test-macosx1014-64/debug-mochitest-browser-chrome-e10s-4 141.60400009155273
test-linux1804-64/debug-mochitest-browser-chrome-fis-e10s-7 117.6800000667572
test-windows7-32/debug-web-platform-tests-reftest-e10s-2 581.414999961853
test-macosx1014-64/debug-xpcshell-e10s-2 110.23099994659424
test-macosx1014-64-shippable/opt-mochitest-devtools-chrome-e10s-3 118.6470000743866
test-linux1804-64-asan/opt-mochitest-browser-chrome-e10s-13 376.37199997901917
test-windows7-32/debug-mochitest-browser-chrome-e10s-3 293.8619999885559
test-linux1804-64-asan/opt-mochitest-browser-chrome-e10s-13 124.0220000743866
```
