### PR TITLE
Don't consider manifest-level pushes for finding label-level regressions

### DIFF
--- a/mozci/push.py
+++ b/mozci/push.py
@@ -411,6 +411,20 @@ class Push:
         """
         return set(t.label for t in self.tasks)
 
+    @property
+    def is_manifest_level(self):
+        """Whether a non-default manifest loader was used for this push.
+
+        Returns:
+            bool: True if a non-default manifest loader was used.
+        """
+        return (
+            self.decision_task.get_artifact("public/parameters.yml")[
+                "test_manifest_loader"
+            ]
+            != "default"
+        )
+
     @memoized_property
     def target_task_labels(self):
         """The set of all task labels that could possibly run on this push.

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -518,7 +518,7 @@ class Push:
             dict: A dictionary of the form {<label>: [<LabelSummary>]}.
         """
         # We can't consider tasks from manifest-level pushes for finding label-level regressions
-        # because tasks with the same name on different pushes might contain totally different tasks.
+        # because tasks with the same name on different pushes might contain totally different tests.
         if self.is_manifest_level:
             return {}
 

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -411,7 +411,7 @@ class Push:
         """
         return set(t.label for t in self.tasks)
 
-    @property
+    @memoized_property
     def is_manifest_level(self):
         """Whether a non-default manifest loader was used for this push.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
+import re
 
 import pytest
 from responses import RequestsMock
@@ -78,6 +79,15 @@ def create_push(monkeypatch, responses):
             content_type="application/json",
         )
 
+        responses.add(
+            responses.GET,
+            re.compile(
+                "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/.*/artifacts"
+            ),
+            json={"artifacts": []},
+            status=200,
+        )
+
         push = Push(rev, branch)
         push._id = push_id
         push_rev_to_id[rev] = push_id
@@ -85,6 +95,7 @@ def create_push(monkeypatch, responses):
         push.bugs = {push_id}
         push.tasks = []
         push._revs = [push.rev]
+        push.is_manifest_level = False
 
         if prev_push:
             push.parent = prev_push


### PR DESCRIPTION
Since tasks with the same name on different pushes might contain totally different tests, our algorithm at the label-level would be totally broken.