### PR TITLE
Allow commits to continue after black / isort make modifications

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,13 @@ repos:
 -   repo: https://github.com/timothycrosley/isort
     rev: 4.3.21
     hooks:
-    -   id: isort
+    - id: isort
+      entry: bash -c 'isort "$@"; git add -u' --
 -   repo: https://github.com/ambv/black
     rev: stable
     hooks:
     - id: black
+      entry: bash -c 'black "$@"; git add -u' --
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.9
     hooks:


### PR DESCRIPTION
This change will silently incorporate the modifications that black / isort make into the commit (rather than failing and then requiring that the commit be re-run).

The author of pre-commit refuses to implement this and advises against doing this, as it means that what you have in your working directory isn't what ends up in the commit. While I do sympathize with this to some degree, in our case I found that 100% of the time was running:
```
$ git commit -a --amend
# black re-wrote stuff; commit fails
# didn't bother checking the modifications
$ git commit -a --amend
# now it works
```

Now the first `git commit -a --amend` will pass.