### PR TITLE
Make the maximum number of parents or children to look for previous/next task runs configurable

### DIFF
--- a/mozci/push.py
+++ b/mozci/push.py
@@ -32,7 +32,7 @@ from mozci.util.hgmo import HGMO
 
 BASE_INDEX = "gecko.v2.{branch}.revision.{rev}"
 
-MAX_DEPTH = 14
+MAX_DEPTH = config.get("maxdepth", 20)
 """The maximum number of parents or children to look for previous/next task runs,
 when the task did not run on the currently considered push.
 """

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -692,7 +692,7 @@ def test_child_failed_and_bustage_fixed(create_pushes):
     p[len(p) - 1].tasks = [Task.create(id="1", label="test-prova", result="success")]
     p[len(p) - 1].bugs = {123}
 
-    assert p[i].get_regressions("label") == {"test-prova": 6}
+    assert p[i].get_regressions("label") == {"test-prova": 10}
 
 
 def test_child_failed_and_not_backedout(create_pushes):
@@ -1802,7 +1802,7 @@ def test_fixed_by_commit_multiple_backout(monkeypatch, create_pushes):
             return int(p[i]._id)
         elif cls.context["rev"] == "rev3":
             return int(3)
-        elif cls.context["rev"] == "rev18":
+        elif cls.context["rev"] == "rev24":
             return int(18)
         else:
             raise Exception(cls.context["rev"])


### PR DESCRIPTION
Given that we have recently moved the backstop to be once every 20 pushes (https://hg.mozilla.org/mozilla-central/rev/17a6cf8777b1), we can't keep looking only in the previous/next 14 pushes.

Fixes #8

31 is a relatively big number, but in the end it should be fast enough when things are cached.