### PR TITLE
Add some additional methods to the taskcluster module

### DIFF
--- a/mozci/util/taskcluster.py
+++ b/mozci/util/taskcluster.py
@@ -6,11 +6,13 @@
 import functools
 
 import taskcluster_urls as liburls
+from taskcluster.helper import TaskclusterConfig
 
 from mozci.util import yaml
 from mozci.util.req import get_session
 
 PRODUCTION_TASKCLUSTER_ROOT_URL = "https://firefox-ci-tc.services.mozilla.com"
+taskcluster_config = TaskclusterConfig(PRODUCTION_TASKCLUSTER_ROOT_URL)
 
 
 def _do_request(url, force_get=False, **kwargs):
@@ -84,3 +86,15 @@ def get_task_url(task_id):
 def get_task(task_id, use_proxy=False):
     response = _do_request(get_task_url(task_id))
     return response.json()
+
+
+def get_tasks_in_group(group_id):
+    tasks = []
+
+    def _save_tasks(response):
+        tasks.extend(response["tasks"])
+
+    queue = taskcluster_config.get_service("queue")
+    queue.listTaskGroup(group_id, paginationHandler=_save_tasks)
+
+    return tasks

--- a/mozci/util/taskcluster.py
+++ b/mozci/util/taskcluster.py
@@ -73,3 +73,14 @@ def get_index_url(index_path):
 def find_task_id(index_path, use_proxy=False):
     response = _do_request(get_index_url(index_path))
     return response.json()["taskId"]
+
+
+def get_task_url(task_id):
+    return liburls.api(
+        PRODUCTION_TASKCLUSTER_ROOT_URL, "queue", "v1", f"task/{task_id}"
+    )
+
+
+def get_task(task_id, use_proxy=False):
+    response = _do_request(get_task_url(task_id))
+    return response.json()

--- a/poetry.lock
+++ b/poetry.lock
@@ -828,8 +828,7 @@ python-versions = "*"
 version = "0.14.0"
 
 [metadata]
-content-hash = "7a90a275d22e4b28b1920086f07d5cfaebeec4fa975b824a92e5e2ee3c6c9301"
-lock-version = "1.0"
+content-hash = "763bc5368b2ad9426a95bb20ebdda636af84a6844b5b802410f156a8ee0b57a3"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -986,7 +985,6 @@ mohawk = [
 ]
 nodeenv = [
     {file = "nodeenv-1.4.0-py2.py3-none-any.whl", hash = "sha256:4b0b77afa3ba9b54f4b6396e60b0c83f59eaeb2d63dc3cc7a70f7f4af96c82bc"},
-    {file = "nodeenv-1.4.0.tar.gz", hash = "sha256:26941644654d8dd5378720e38f62a3bac5f9240811fb3b8913d2663a17baa91c"},
 ]
 packaging = [
     {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ redis = {version = "^3.5.3", optional = true}
 requests = "^2.24.0"
 voluptuous = ">=0.11.7,<0.13.0"
 flake8 = "^3.8.3"
+taskcluster = "^30.1.1"
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.7"


### PR DESCRIPTION
To support #304.

E.g. to get all tasks belonging to a given push:
```
decision_task_id = taskcluster.find_task_id(f"gecko.v2.{branch}.revision.{rev}.taskgraph.decision")
decision_task_data = taskcluster.get_task(decision_task_id)  # could avoid this request and always assume the decision_task_id is the same as the group ID.
tasks = get_tasks_in_group(decision_task_data["taskGroupId"])
```