### PR TITLE
Use json-automationrelevance to retrieve all information about commits

### DIFF
--- a/mozci/push.py
+++ b/mozci/push.py
@@ -64,7 +64,7 @@ class Push:
         if len(revs[0]) == 40:
             self.rev = revs[0]
         else:
-            self.rev = self._hgmo["node"]
+            self.rev = self._hgmo.node
 
         self.index = BASE_INDEX.format(branch=self.branch, rev=self.rev)
         # Unique identifier for a Push across branches
@@ -83,7 +83,7 @@ class Push:
         Returns:
             str or None: The commit revision which backs this push out (or None).
         """
-        return self._hgmo.get("backedoutby") or None
+        return self._hgmo.backedoutby or None
 
     @property
     def backedout(self):
@@ -113,7 +113,7 @@ class Push:
         if self._date:
             return self._date
 
-        self._date = self._hgmo["pushdate"][0]
+        self._date = self._hgmo.pushdate
         return self._date
 
     @property
@@ -126,7 +126,7 @@ class Push:
         if self._id:
             return self._id
 
-        self._id = self._hgmo["pushid"]
+        self._id = self._hgmo.pushid
         return self._id
 
     def create_push(self, push_id):
@@ -181,7 +181,7 @@ class Push:
         for branch in branches:
             try:
                 hgmo = HGMO.create(parent_rev, branch=branch)
-                head = hgmo.changesets[0]["pushhead"]
+                head = hgmo.pushhead
             except PushNotFound:
                 continue
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,23 +39,16 @@ def create_push(monkeypatch, responses):
 
     monkeypatch.setattr(HGMO, "pushid", property(mock_pushid))
 
-    def inner(rev=None, branch="integration/autoland", json_data=None):
+    def mock_node(cls):
+        return cls.context["rev"]
+
+    monkeypatch.setattr(HGMO, "node", property(mock_node))
+
+    def inner(rev=None, branch="integration/autoland"):
         nonlocal prev_push, push_id
 
         if not rev:
             rev = "rev{}".format(push_id)
-
-        if json_data is None:
-            json_data = {
-                "node": rev,
-            }
-
-        responses.add(
-            responses.GET,
-            HGMO.JSON_TEMPLATE.format(branch=branch, rev=rev),
-            json=json_data,
-            status=200,
-        )
 
         def automationrelevance_callback(request):
             *repo, _, revision = request.path_url[1:].split("/")

--- a/tests/test_hgmo.py
+++ b/tests/test_hgmo.py
@@ -100,15 +100,3 @@ def test_hgmo_backouts(responses):
     h = HGMO("abcdef")
     assert h.backouts == {"789": ["123456"], "ghi": ["789"]}
     assert h.changesets[0]["backsoutnodes"] == [{"node": "123456"}]
-
-
-def test_hgmo_json_data(responses):
-    responses.add(
-        responses.GET,
-        "https://hg.mozilla.org/integration/autoland/rev/abcdef?style=json",
-        json={"backedoutby": "123456"},
-        status=200,
-    )
-
-    h = HGMO("abcdef")
-    assert h.get("backedoutby") == "123456"

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -61,14 +61,18 @@ def test_create_push(responses):
         )
         responses.add(
             responses.GET,
-            HGMO.JSON_TEMPLATE.format(branch=ctx["branch"], rev="abcdef"),
-            json={"node": "abcdef"},
+            HGMO.AUTOMATION_RELEVANCE_TEMPLATE.format(
+                branch=ctx["branch"], rev="abcdef"
+            ),
+            json={"changesets": [{"node": "abcdef"}]},
             status=200,
         )
         responses.add(
             responses.GET,
-            HGMO.JSON_TEMPLATE.format(branch=ctx["branch"], rev="123456"),
-            json={"node": "123456"},
+            HGMO.AUTOMATION_RELEVANCE_TEMPLATE.format(
+                branch=ctx["branch"], rev="123456"
+            ),
+            json={"changesets": [{"node": "123456"}]},
             status=200,
         )
 
@@ -100,7 +104,9 @@ def test_push_does_not_exist(responses):
     rev = "foobar"
     responses.add(
         responses.GET,
-        HGMO.JSON_TEMPLATE.format(branch="integration/autoland", rev=rev),
+        HGMO.AUTOMATION_RELEVANCE_TEMPLATE.format(
+            branch="integration/autoland", rev="foobar"
+        ),
         json={"error": f"unknown revision '{rev}'"},
         status=404,
     )
@@ -112,7 +118,9 @@ def test_push_does_not_exist(responses):
     rev = "a" * 40
     responses.add(
         responses.GET,
-        HGMO.JSON_TEMPLATE.format(branch="integration/autoland", rev=rev),
+        HGMO.AUTOMATION_RELEVANCE_TEMPLATE.format(
+            branch="integration/autoland", rev=rev
+        ),
         json={"error": f"unknown revision '{rev}'"},
         status=404,
     )


### PR DESCRIPTION
Instead of relying on both json-rev and json-automationrelevance.

Fixes #331

This depends on adding `backedoutby` information in json-automationrelevance.