### PR TITLE
Treeherder datasource push test groups

### DIFF
--- a/mozci/data/sources/treeherder/__init__.py
+++ b/mozci/data/sources/treeherder/__init__.py
@@ -144,6 +144,7 @@ class TreeherderDBSource(BaseTreeherderSource):
         return tasks
 
     def run_push_tasks(self, branch, rev):
+        keys = ("id", "label", "result", "duration", "tags", "state")
         if not Job:
             raise ContractNotFilled(
                 self.name, "push_tasks", "could not import Job model"
@@ -153,11 +154,9 @@ class TreeherderDBSource(BaseTreeherderSource):
 
         return [
             {
-                "id": task_data["id"],
-                "label": task_data["label"],
-                "result": task_data["result"],
-                "duration": task_data["duration"],
-                "tags": task_data["tags"],
+                key: task_data[key]
+                for key in keys
+                if not (key == "result" and task_data[key] == "unknown")
             }
             for task_id, task_data in tasks.items()
         ]

--- a/mozci/data/sources/treeherder/__init__.py
+++ b/mozci/data/sources/treeherder/__init__.py
@@ -92,6 +92,7 @@ class TreeherderDBSource(BaseTreeherderSource):
                 "id": str(task_id),
                 "label": job.job_type.name,
                 "result": job.result,
+                "state": job.state,
                 "classification": job.failure_classification.name,
                 "classification_note": note,
                 "duration": Job.get_duration(
@@ -102,7 +103,7 @@ class TreeherderDBSource(BaseTreeherderSource):
             result_map = {
                 "success": "passed",
                 "testfailed": "failed",
-                "bustage": "failed",
+                "busted": "failed",
                 "usercancel": "canceled",
                 "retry": "exception",
             }

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -241,10 +241,14 @@ class TestTask(Task):
 
     def __post_init__(self):
         if is_no_groups_suite(self.label):
-            assert self._errors is None, f"{self.label} should have no errors"
+            assert (
+                self._errors is None
+            ), f"{self.id} : {self.label} should have no errors"
             self._errors = []
 
-            assert self._results is None, f"{self.label} should have no results"
+            assert (
+                self._results is None
+            ), f"{self.id} : {self.label} should have no results"
             self._results = []
 
         if self._results is None:


### PR DESCRIPTION
This adds `push_test_groups` contract support to the Treeherder Datasource.  It also fixes a couple things that were broken with the recent changes.  When a task is in-progress, it has a result of `unknown`.  And we get the result of `busted` rather than `bustage` in our Tasks.