### PR TITLE
Assume a commit was not backed-out if the 'backedoutby' field is not present in json-automationrelevance

### DIFF
--- a/mozci/push.py
+++ b/mozci/push.py
@@ -83,7 +83,7 @@ class Push:
         Returns:
             str or None: The commit revision which backs this push out (or None).
         """
-        return self._hgmo.backedoutby or None
+        return self._hgmo.backedoutby
 
     @property
     def backedout(self):

--- a/mozci/util/hgmo.py
+++ b/mozci/util/hgmo.py
@@ -99,7 +99,10 @@ class HGMO:
 
     @property
     def backedoutby(self):
-        return self._find_self()["backedoutby"]
+        self_changeset = self._find_self()
+        return (
+            self_changeset["backedoutby"] if "backedoutby" in self_changeset else None
+        )
 
     @property
     def backouts(self):

--- a/tests/test_hgmo.py
+++ b/tests/test_hgmo.py
@@ -100,3 +100,42 @@ def test_hgmo_backouts(responses):
     h = HGMO("abcdef")
     assert h.backouts == {"789": ["123456"], "ghi": ["789"]}
     assert h.changesets[0]["backsoutnodes"] == [{"node": "123456"}]
+
+
+def test_hgmo_backedoutby(responses):
+    responses.add(
+        responses.GET,
+        "https://hg.mozilla.org/integration/autoland/json-automationrelevance/abcdef",
+        json={
+            "changesets": [
+                {
+                    "node": "abcdef",
+                    "backsoutnodes": [{"node": "123456"}],
+                    "pushhead": "abcdef",
+                }
+            ]
+        },
+        status=200,
+    )
+
+    responses.add(
+        responses.GET,
+        "https://hg.mozilla.org/integration/autoland/json-automationrelevance/123456",
+        json={
+            "changesets": [
+                {
+                    "node": "123456",
+                    "backedoutby": "abcdef",
+                    "backsoutnodes": [],
+                    "pushhead": "123456",
+                },
+            ]
+        },
+        status=200,
+    )
+
+    h = HGMO("abcdef")
+    assert h.backedoutby is None
+
+    h = HGMO("123456")
+    assert h.backedoutby == "abcdef"


### PR DESCRIPTION
The behavior of json-rev and json-automationrelevance are a bit different for non backed-out commits.
The first always has a 'backedoutby' field, and it is empty in case of non backed-out commits.
The second doesn't have a 'backedoutby' field for non backed-out commits.

Fixes #342