### PR TITLE
Replace `bustage` with `busted` in the map to translate ActiveData results

### DIFF
--- a/mozci/data/sources/activedata/__init__.py
+++ b/mozci/data/sources/activedata/__init__.py
@@ -62,7 +62,7 @@ class ActiveDataSource(DataSource):
             result_map = {
                 "success": "passed",
                 "testfailed": "failed",
-                "bustage": "failed",
+                "busted": "failed",
                 "usercancel": "canceled",
                 "retry": "exception",
             }


### PR DESCRIPTION
Fixes #344