### PR TITLE
Don't memoize the Task artifacts property

### DIFF
--- a/mozci/task.py
+++ b/mozci/task.py
@@ -172,7 +172,7 @@ class Task:
     def failed(self):
         return self.result in ("failed", "exception")
 
-    @memoized_property
+    @property
     def artifacts(self):
         """List the artifacts that were uploaded by this task."""
         return [artifact["name"] for artifact in list_artifacts(self.id)]


### PR DESCRIPTION
It is only used once, there is no need to memoize it.