### PR TITLE
Return an empty dict if no errorsummary loaded in ErrorsummarySource

### DIFF
--- a/mozci/data/sources/artifact/__init__.py
+++ b/mozci/data/sources/artifact/__init__.py
@@ -67,9 +67,9 @@ class ErrorSummarySource(DataSource):
     def run_test_task_groups(self, task):
         if task.id not in self.TASK_GROUPS:
             self._load_errorsummary(task.id)
-        return self.TASK_GROUPS.pop(task.id)
+        return self.TASK_GROUPS.pop(task.id, {})
 
     def run_test_task_errors(self, task):
         if task.id not in self.TASK_ERRORS:
             self._load_errorsummary(task.id)
-        return self.TASK_ERRORS.pop(task.id)
+        return self.TASK_ERRORS.pop(task.id, {})


### PR DESCRIPTION
This can happen if the task hasn't been scheduled yet. I decided to
return an empty dict rather than raise ContractNotFilled since this
should typically be the last data source in the list and we likely don't
want to raise every time a task is still running / pending.