### PR TITLE
Set incomplete task results to an empty list

### DIFF
--- a/mozci/push.py
+++ b/mozci/push.py
@@ -285,7 +285,6 @@ class Push:
                 )
                 for task in tasks
                 if isinstance(task, TestTask)
-                if task.state == "completed"
             ],
             return_when=concurrent.futures.FIRST_EXCEPTION,
         )

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -251,12 +251,15 @@ class TestTask(Task):
 
             return
 
-        self._results = [
-            GroupResult(group, result)
-            for group, result in data.handler.get(
-                "test_task_groups", branch=push.branch, rev=push.rev, task=self
-            ).items()
-        ]
+        if self.state == "completed":
+            self._results = [
+                GroupResult(group, result)
+                for group, result in data.handler.get(
+                    "test_task_groups", branch=push.branch, rev=push.rev, task=self
+                ).items()
+            ]
+        else:
+            self._results = []
 
         # Apply WPT workaround, needed at least until bug 1632546 is fixed.
         if self.is_wpt:


### PR DESCRIPTION
The task.results attribute expects the _results property to have a value.
Since e488ccd4966163ed9532ab51f4584fc60286ae10, we don't populate _results
at the time of task creation for incomplete tasks (e.g. tasks ending with
'exception'). Later on, we try to access the task.results attribute for all
tasks, even incomplete ones, and so the assertion on _results not being None
fails.

Fixes #473, a regression from e488ccd4966163ed9532ab51f4584fc60286ae10