### PR TITLE
Make 'tier' optional in the 'push_tasks' contract

### DIFF
--- a/mozci/data/contract.py
+++ b/mozci/data/contract.py
@@ -54,7 +54,7 @@ _contracts: Tuple[Contract, ...] = (
                         ]
                     ),
                 },
-                optional=["duration", "result"],
+                optional=["duration", "result", "tier"],
             )
         ),
     ),

--- a/mozci/data/sources/taskcluster/__init__.py
+++ b/mozci/data/sources/taskcluster/__init__.py
@@ -56,8 +56,10 @@ class TaskclusterSource(DataSource):
                 "label": result["task"]["metadata"]["name"],
                 "tags": result["task"]["tags"],
                 "state": result["status"]["state"],
-                "tier": result["task"]["extra"]["treeherder"]["tier"],
             }
+            tier = result["task"]["extra"].get("treeherder", {}).get("tier")
+            if tier:
+                task["tier"] = tier
 
             # Use the latest run (earlier ones likely had exceptions that
             # caused an automatic retry).

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -305,9 +305,7 @@ class Push:
         logger.debug(f"Retrieved all tasks and groups which run on {self.rev}.")
 
         # Skip tier tasks greater than the tier passed in config
-        # Note: Default tier is 2
-        logger.info(f"{tasks[0]}")
-        tasks = [task for task in tasks if task.tier <= config.tier]
+        tasks = [task for task in tasks if not task.tier or task.tier <= config.tier]
 
         # Now we can cache the results.
         # cachy's put() overwrites the value in the cache; add() would only add if its empty


### PR DESCRIPTION
Not all tasks have a `treeherder` section in the taskcluster data source, so tier needs to be optional.