### PR TITLE
Classify regressions and push using bugbug data

### DIFF
--- a/mozci/push.py
+++ b/mozci/push.py
@@ -49,11 +49,11 @@ class PushStatus(Enum):
 
 @dataclass
 class Regressions:
-    # These 3 attributes are dicts of list of configurations
-    # each item being a single group, with its failing configurations
-    real: Dict[str, List[str]]
-    intermittent: Dict[str, List[str]]
-    unknown: Dict[str, List[str]]
+    # These 3 attributes are dicts of list of tasks
+    # each item being a single group, with its failing tasks
+    real: Dict[str, List[TestTask]]
+    intermittent: Dict[str, List[TestTask]]
+    unknown: Dict[str, List[TestTask]]
 
 
 class Push:
@@ -1072,19 +1072,16 @@ class Push:
         )
         logger.debug(f"Got {len(unknown_failures)} unknown failures")
 
-        def _map_failing_configurations(groups):
-            # Link all the failing configurations on the given groups
-            return {
-                name: self.group_summaries[name].failing_configurations
-                for name in groups
-            }
+        def _map_failing_tasks(groups):
+            # Link all the failing tasks on the given groups
+            return {name: self.group_summaries[name].failing_tasks for name in groups}
 
         # Output real, intermittent and unknown groupfailures
         # along with their failing configurations
         return Regressions(
-            real=_map_failing_configurations(real_failures),
-            intermittent=_map_failing_configurations(intermittent_failures),
-            unknown=_map_failing_configurations(unknown_failures),
+            real=_map_failing_tasks(real_failures),
+            intermittent=_map_failing_tasks(intermittent_failures),
+            unknown=_map_failing_tasks(unknown_failures),
         )
 
     def classify(

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -49,9 +49,11 @@ class PushStatus(Enum):
 
 @dataclass
 class Regressions:
-    real: Set[str]
-    intermittent: Set[str]
-    unknown: Set[str]
+    # These 3 attributes are dicts of list of configurations
+    # each item being a single group, with its failing configurations
+    real: Dict[str, List[str]]
+    intermittent: Dict[str, List[str]]
+    unknown: Dict[str, List[str]]
 
 
 class Push:
@@ -1076,10 +1078,19 @@ class Push:
         )
         logger.debug(f"Got {len(unknown_failures)} unknown failures")
 
+        def _map_failing_configurations(groups):
+            # Link all the failing configurations on the given groups
+            return {
+                name: self.group_summaries[name].failing_configurations
+                for name in groups
+            }
+
+        # Output real, intermittent and unknown groupfailures
+        # along with their failing configurations
         return Regressions(
-            real=real_failures,
-            intermittent=intermittent_failures,
-            unknown=unknown_failures,
+            real=_map_failing_configurations(real_failures),
+            intermittent=_map_failing_configurations(intermittent_failures),
+            unknown=_map_failing_configurations(unknown_failures),
         )
 
     def classify(

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -1103,7 +1103,7 @@ class Push:
         - good push: when there are only intermittent failures
         - unknown state: when other tasks are failing
         """
-        regressions = self.classify_regressions()
+        regressions = self.classify_regressions(confidence_medium, confidence_high)
 
         # If there are any real failures, it's a bad push
         if len(regressions.real) > 0:

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -1001,16 +1001,10 @@ class Push:
                 config["cache"]["retention"],
             )
 
-        # Fetch likely group regressions for that push from cache or treeherder + Taskcluster
-        groups_likely_regressions = config.cache.get(cache_prefix + "group_regressions")
-        if groups_likely_regressions is None:
-            groups_likely_regressions = self.get_likely_regressions("group")
-
-            config.cache.put(
-                cache_prefix + "group_regressions",
-                groups_likely_regressions,
-                config["cache"]["retention"],
-            )
+        # Fetch likely group regressions for that push from treeherder + Taskcluster
+        # We do not cache these results as we might want to analyze in-progress
+        # pushes and keep updating these values
+        groups_likely_regressions = self.get_likely_regressions("group")
 
         # Get task groups with high and low confidence from bugbug scheduling
         groups_high = {

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -423,12 +423,10 @@ class GroupSummary(RunnableSummary):
         nb_passed = sum(states)  # Number of True booleans in the states list
         nb_failed = nb - nb_passed
 
-        if nb_passed and nb_failed:
-            # Tasks both passed and failed, this isn't a cross failure
-            return False
-
-        # If there are failures, this is a cross failure, else not
-        return nb_failed > 0
+        # Given that a group is NOT a cross config failure
+        # when all tasks passed OR failed, we can explicitly
+        # write the decision by its opposite
+        return not (nb_passed == nb or nb_failed == nb)
 
 
 @dataclass

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import itertools
 import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -409,6 +410,15 @@ class GroupSummary(RunnableSummary):
 
         # Otherwise, the manifest passed in all tasks, so we consider it a pass.
         return Status.PASS
+
+    @memoized_property
+    def failing_configurations(self):
+
+        # Group all tasks by configurations
+        confs = itertools.groupby(self.tasks, lambda t: t.configuration)
+
+        # List configurations where some tasks are failing
+        return [name for name, tasks in confs if any(t.failed for t in tasks)]
 
     @memoized_property
     def is_cross_config_failure(self):

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -433,10 +433,10 @@ class GroupSummary(RunnableSummary):
         nb_passed = sum(states)  # Number of True booleans in the states list
         nb_failed = nb - nb_passed
 
-        # Given that a group is NOT a cross config failure
-        # when all tasks passed OR failed, we can explicitly
-        # write the decision by its opposite
-        return not (nb_passed == nb or nb_failed == nb)
+        # A group is a cross config failure when
+        # - some (not all) tasks have failed
+        # - AND some (not all) tasks have succeeded
+        return nb_passed != nb and nb_failed != nb
 
 
 @dataclass

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -410,6 +410,26 @@ class GroupSummary(RunnableSummary):
         # Otherwise, the manifest passed in all tasks, so we consider it a pass.
         return Status.PASS
 
+    @memoized_property
+    def is_cross_config_failure(self):
+        states = [
+            result.ok
+            for task in self.tasks
+            for result in task.results
+            if result.group == self.name
+        ]
+
+        nb = len(states)
+        nb_passed = sum(states)  # Number of True booleans in the states list
+        nb_failed = nb - nb_passed
+
+        if nb_passed and nb_failed:
+            # Tasks both passed and failed, this isn't a cross failure
+            return False
+
+        # If there are failures, this is a cross failure, else not
+        return nb_failed > 0
+
 
 @dataclass
 class LabelSummary(RunnableSummary):

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-import itertools
 import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -412,13 +411,15 @@ class GroupSummary(RunnableSummary):
         return Status.PASS
 
     @memoized_property
-    def failing_configurations(self):
-
-        # Group all tasks by configurations
-        confs = itertools.groupby(self.tasks, lambda t: t.configuration)
-
-        # List configurations where some tasks are failing
-        return [name for name, tasks in confs if any(t.failed for t in tasks)]
+    def failing_tasks(self):
+        # List all tasks with some test results failing for that group
+        return [
+            task
+            for task in self.tasks
+            if any(
+                not result.ok and result.group == self.name for result in task.results
+            )
+        ]
 
     @memoized_property
     def is_cross_config_failure(self):

--- a/test.py
+++ b/test.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+from pprint import pprint
+
+from mozci.push import Push
+
+p = Push(["4185629111d323484d1f74a667d57145616203b7"], "mozilla-central")
+pprint(p.classify_regressions())

--- a/test.py
+++ b/test.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-from pprint import pprint
 
 from mozci.push import Push
 
 p = Push(["4185629111d323484d1f74a667d57145616203b7"], "mozilla-central")
-pprint(p.classify_regressions())
+print(p.classify())

--- a/test.py
+++ b/test.py
@@ -1,6 +1,0 @@
-# -*- coding: utf-8 -*-
-
-from mozci.push import Push
-
-p = Push(["4185629111d323484d1f74a667d57145616203b7"], "mozilla-central")
-print(p.classify())

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -8,6 +8,9 @@ from mozci.errors import ArtifactNotFound, TaskNotFound
 from mozci.task import GroupResult, GroupSummary, Task
 from mozci.util.taskcluster import get_artifact_url, get_index_url
 
+GR_2 = GroupResult(group="group2", ok=True)
+GR_3 = GroupResult(group="group2", ok=True)
+
 
 class FakePush:
     def __init__(self, branch, rev):
@@ -237,3 +240,58 @@ def test_results_for_incomplete_task(responses):
     assert task.results == [
         GroupResult(group="layout/base/tests/browser.ini", ok=True),
     ]
+
+
+@pytest.mark.parametrize(
+    "group_summary, expected_result",
+    [
+        (
+            GroupSummary(
+                "group1",
+                [
+                    Task.create(
+                        id=i,
+                        label=f"test-task{i}",
+                        _results=[GroupResult(group="group1", ok=False), GR_2, GR_3],
+                    )
+                    for i in range(1, 11)
+                ],
+            ),
+            True,
+        ),  # All related tasks failed
+        (
+            GroupSummary(
+                "group1",
+                [
+                    Task.create(
+                        id=i,
+                        label=f"test-task{i}",
+                        _results=[
+                            GroupResult(group="group1", ok=False if i % 2 else True),
+                            GR_2,
+                            GR_3,
+                        ],
+                    )
+                    for i in range(1, 11)
+                ],
+            ),
+            False,
+        ),  # Related tasks both failed and passed
+        (
+            GroupSummary(
+                "group1",
+                [
+                    Task.create(
+                        id=i,
+                        label=f"test-task{i}",
+                        _results=[GroupResult(group="group1", ok=True), GR_2, GR_3],
+                    )
+                    for i in range(1, 11)
+                ],
+            ),
+            False,
+        ),  # All related tasks passed
+    ],
+)
+def test_GroupSummary_is_cross_config_failure(group_summary, expected_result):
+    assert group_summary.is_cross_config_failure == expected_result

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -257,7 +257,7 @@ def test_results_for_incomplete_task(responses):
                     for i in range(1, 11)
                 ],
             ),
-            True,
+            False,
         ),  # All related tasks failed
         (
             GroupSummary(
@@ -275,7 +275,7 @@ def test_results_for_incomplete_task(responses):
                     for i in range(1, 11)
                 ],
             ),
-            False,
+            True,
         ),  # Related tasks both failed and passed
         (
             GroupSummary(


### PR DESCRIPTION
Closes #504 

Algorithm implemented in `classify_regressions` for a push  is :
1. get schedules from bugbug (or local cache)
2. get likely regressions from mozci  (or local cache)
3. sort bugbug groups into high & low confidence buckets (excluding the medium ones)
4. detect if likely regressions is a cross config failure or not
5. get all groups that fail
6. build the group lists:
  - real failures = `likely_regressions & groups_cross_config_failure & groups_high`
  - intermittent failures = `groups_non_cross_config_failure & groups_low`
  - unknown failures = remaining failures not in the two previous lists

A second method `classify` simply gets those list and extrapolates a single value for the whole push:
- `PushStatus.BAD` when there are real failures 
- `PushStatus.GOOD` when there are only intermittent failures
- fallback to `PushStatus.UNKNOWN`

:warning: the `test.py` at the root level should be removed before merge, it's just for debugging (and would be implemented cleanly in https://github.com/mozilla/mozci-tools/issues/15).