### PR TITLE
Add docker image based on alpine

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -51,8 +51,8 @@ tasks:
     - taskId: { $eval: as_slugid("docker_build") }
       created: { $fromNow: "" }
       deadline: { $fromNow: "1 hour" }
-      dependencies:
-        - { $eval: as_slugid("tests_task") }
+      #dependencies:
+      #  - { $eval: as_slugid("tests_task") }
       provisionerId: proj-relman
       workerType: ci
       payload:
@@ -61,7 +61,7 @@ tasks:
         maxRunTime: 3600
         image: docker:20.10
         command:
-          - "/bin/bash"
+          - "/bin/sh"
           - "-lcx"
           - "apk add git &&
             git clone --quiet ${repository} &&

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -59,7 +59,7 @@ tasks:
         features:
           dind: true
         maxRunTime: 3600
-        image: mozilla/taskboot:0.2.2
+        image: mozilla/taskboot:0.3.3
         env:
           GIT_REPOSITORY: ${repository}
           GIT_REVISION: ${head_rev}
@@ -76,9 +76,9 @@ tasks:
           - /mozci.tar
           - Dockerfile
         artifacts:
-          public/mozci.tar:
+          public/mozci.tar.zst:
             expires: { $fromNow: "1 month" }
-            path: /mozci.tar
+            path: /mozci.tar.zst
             type: file
       routes:
         $if: 'tasks_for == "github-pull-request"'
@@ -107,7 +107,7 @@ tasks:
         maxRunTime: 3600
         image:
           type: task-image
-          path: public/mozci.tar
+          path: public/mozci.tar.zst
           taskId: { $eval: as_slugid("docker_build") }
         env:
           GIT_REPOSITORY: ${repository}

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -51,8 +51,8 @@ tasks:
     - taskId: { $eval: as_slugid("docker_build") }
       created: { $fromNow: "" }
       deadline: { $fromNow: "1 hour" }
-      #dependencies:
-      #  - { $eval: as_slugid("tests_task") }
+      dependencies:
+        - { $eval: as_slugid("tests_task") }
       provisionerId: proj-relman
       workerType: ci
       payload:

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -59,15 +59,27 @@ tasks:
         features:
           dind: true
         maxRunTime: 3600
-        image: docker:19.03
+        image: mozilla/taskboot:0.2.2
+        env:
+          GIT_REPOSITORY: ${repository}
+          GIT_REVISION: ${head_rev}
         command:
-          - "/bin/sh"
-          - "-lcx"
-          - "apk add git &&
-            git clone --quiet ${repository} &&
-            cd mozci &&
-            git -c advice.detachedHead=false checkout ${head_rev} &&
-            docker build . -t mozilla/mozci"
+          - taskboot
+          - build
+          - --build-tool
+          - dind
+          - --image
+          - mozilla/mozci
+          - --tag
+          - "${head_rev}"
+          - --write
+          - /mozci.tar
+          - Dockerfile
+        artifacts:
+          public/mozci.tar:
+            expires: { $fromNow: "1 month" }
+            path: /mozci.tar
+            type: file
       metadata:
         name: mozci docker build
         description: mozci docker build

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -59,7 +59,7 @@ tasks:
         features:
           dind: true
         maxRunTime: 3600
-        image: docker:20.10
+        image: docker:19.03
         command:
           - "/bin/sh"
           - "-lcx"

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -80,8 +80,42 @@ tasks:
             expires: { $fromNow: "1 month" }
             path: /mozci.tar
             type: file
+      routes:
+        $if: 'tasks_for == "github-pull-request"'
+        then:
+          - "index.project.mozci.docker-pr.revision.${head_rev}"
+          - "index.project.mozci.docker-pr.revision.${head_branch}"
+        else:
+          - "index.project.mozci.docker.revision.${head_rev}"
+          - "index.project.mozci.docker.revision.${head_branch}"
       metadata:
         name: mozci docker build
         description: mozci docker build
+        owner: mcastelluccio@mozilla.com
+        source: ${repository}/raw/${head_rev}/.taskcluster.yml
+
+    - taskId: { $eval: as_slugid("docker_test") }
+      created: { $fromNow: "" }
+      deadline: { $fromNow: "1 hour" }
+      dependencies:
+        - { $eval: as_slugid("docker_build") }
+      provisionerId: proj-relman
+      workerType: ci
+      payload:
+        features:
+          dind: true
+        maxRunTime: 3600
+        image:
+          type: task-image
+          path: public/mozci.tar
+          taskId: { $eval: as_slugid("docker_build") }
+        env:
+          GIT_REPOSITORY: ${repository}
+          GIT_REVISION: ${head_rev}
+        command:
+          - help
+      metadata:
+        name: mozci docker test
+        description: mozci docker test
         owner: mcastelluccio@mozilla.com
         source: ${repository}/raw/${head_rev}/.taskcluster.yml

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -47,3 +47,29 @@ tasks:
         description: mozci linting and tests
         owner: mcastelluccio@mozilla.com
         source: ${repository}/raw/${head_rev}/.taskcluster.yml
+
+    - taskId: { $eval: as_slugid("docker_build") }
+      created: { $fromNow: "" }
+      deadline: { $fromNow: "1 hour" }
+      dependencies:
+        - { $eval: as_slugid("tests_task") }
+      provisionerId: proj-relman
+      workerType: ci
+      payload:
+        features:
+          dind: true
+        maxRunTime: 3600
+        image: docker:20.10
+        command:
+          - "/bin/bash"
+          - "-lcx"
+          - "apk add git &&
+            git clone --quiet ${repository} &&
+            cd mozci &&
+            git -c advice.detachedHead=false checkout ${head_rev} &&
+            docker build . -t mozilla/mozci"
+      metadata:
+        name: mozci docker build
+        description: mozci docker build
+        owner: mcastelluccio@mozilla.com
+        source: ${repository}/raw/${head_rev}/.taskcluster.yml

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -84,10 +84,10 @@ tasks:
         $if: 'tasks_for == "github-pull-request"'
         then:
           - "index.project.mozci.docker-pr.revision.${head_rev}"
-          - "index.project.mozci.docker-pr.revision.${head_branch}"
+          - "index.project.mozci.docker-pr.branch.${head_branch}"
         else:
           - "index.project.mozci.docker.revision.${head_rev}"
-          - "index.project.mozci.docker.revision.${head_branch}"
+          - "index.project.mozci.docker.branch.${head_branch}"
       metadata:
         name: mozci docker build
         description: mozci docker build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.9-alpine
+
+# Add mozci source code and setup instructions
+WORKDIR /src
+COPY LICENSE  poetry.lock  pyproject.toml  README.md ./
+COPY mozci /src/mozci/
+
+# Run in a single step to get a small image
+RUN apk add --virtual build gcc libffi-dev musl-dev postgresql-dev && \
+  # Setup latest poetry through pip
+  pip install poetry && \
+  # Install mozci with poetry
+  poetry config virtualenvs.create false && \
+  poetry install --no-dev --no-interaction --no-ansi && \
+  # Cleanup build dependencies
+  apk del build && \
+  rm -rf /tmp/build

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY mozci /src/mozci/
 # Run in a single step to get a small image
 RUN apk add --virtual build gcc libffi-dev musl-dev postgresql-dev && \
   # Setup latest poetry through pip
-  pip install poetry && \
+  pip install --no-cache-dir poetry && \
   # Install mozci with poetry
   poetry config virtualenvs.create false && \
   poetry install --no-dev --no-interaction --no-ansi && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,8 @@ RUN apk add --virtual build gcc libffi-dev musl-dev postgresql-dev && \
   poetry config virtualenvs.create false && \
   poetry install --no-dev --no-interaction --no-ansi && \
   # Cleanup build dependencies
+  pip uninstall -y poetry && \
   apk del build && \
   rm -rf /tmp/build
+
+ENTRYPOINT ["mozci"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ loguru = "~0"
 cachy = "~0"
 tomlkit = "~0"
 boto3 = {version = "~1", optional = true}
-zstandard = {version = "~0", optional = true}
+zstandard = {version = "~0"}
 python3-memcached = {version = "~1", optional = true}
 redis = {version = "~3", optional = true}
 requests = "~2"


### PR DESCRIPTION
Closes #545 & #539 

The image is built using [mozilla/task-boot](https://github.com/mozilla/task-boot/) + Taskcluster dind.

It's currently available as a Taskcluster artifact. We now have 2 choices for further publication:
1. only publish as artifact, and index the task so that other Taskcluster task (on the same instance) can use that image
2. add Docker hub credentials in a secret, and use it through `task-boot push-artifact` in order to publish the image on Dockerhub.

We also need to define a publication strategy:
- push as `latest` on `master` (merges) ?
- push as `X.Y.Z` on tags `X.Y.Z` (releases) ?
- push on specific production or other branches ?