### PR TITLE
Strip refs/heads/ from Taskcluster branch index

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -10,7 +10,11 @@ tasks:
       then: ${event.pull_request.head.ref}
       else:
         $if: 'tasks_for == "github-push"'
-        then: ${event.ref}
+        then:
+          # Strip ref branch prefix
+          $if: 'event.ref[0:11] == "refs/heads/"'
+          then: ${event.ref[11:]}
+          else: ${event.ref}
         else: ${event.release.target_commitish}
 
     head_rev:


### PR DESCRIPTION
Port from [code-review definition](https://github.com/mozilla/code-review/blob/master/.taskcluster.yml#L13-L15).

The merged branches are not indexed by their branch name because Taskcluster/Github use a `refs/heads/xxx` structure for its git references: this gives `index.project.mozci.docker.branch.refs/heads/master` for `master` which is invalid.