### PR TITLE
Fix index route in decision children tasks

### DIFF
--- a/mozci/console/commands/decision.py
+++ b/mozci/console/commands/decision.py
@@ -98,8 +98,8 @@ class DecisionCommand(Command):
                 },
             },
             "routes": [
-                f"project.mozci.classification.{push.branch}.revision.{push.rev}",
-                f"project.mozci.classification.{push.branch}.push.{push.id}",
+                f"index.project.mozci.classification.{push.branch}.revision.{push.rev}",
+                f"index.project.mozci.classification.{push.branch}.push.{push.id}",
             ],
             "provisionerId": self.current_task["provisionerId"],
             "workerType": self.current_task["workerType"],


### PR DESCRIPTION
This fixes the route syntax to really index the children tasks, and match the [scopes available to the hook](https://github.com/mozilla/community-tc-config/blob/main/config/projects/mozci.yml#L58)