### PR TITLE
Add a new Cleo command to compare classification results with reality

### DIFF
--- a/mozci/console/commands/push.py
+++ b/mozci/console/commands/push.py
@@ -282,19 +282,19 @@ class ClassifyEvalCommand(Command):
                 f"<error>Failed to fetch or recalculate classification for {len(classification_failed)} out of {len(pushes)} pushes.</error>"
             )
         self.line(
-            f"{len(bad_backedout_pushes)} out of {len(pushes)} pushes were backed-out by a sheriff and were classify as BAD."
+            f"{len(bad_backedout_pushes)} out of {len(pushes)} pushes were backed-out by a sheriff and were classified as BAD."
         )
         self.line(
-            f"{len(bad_non_backedout_pushes)} out of {len(pushes)} pushes weren't backed-out by a sheriff and were classify as BAD."
+            f"{len(bad_non_backedout_pushes)} out of {len(pushes)} pushes weren't backed-out by a sheriff and were classified as BAD."
         )
         self.line(
-            f"{len(good_backedout_pushes)} out of {len(pushes)} pushes were backed-out by a sheriff and were classify as GOOD."
+            f"{len(good_backedout_pushes)} out of {len(pushes)} pushes were backed-out by a sheriff and were classified as GOOD."
         )
         self.line(
-            f"{len(good_non_backedout_pushes)} out of {len(pushes)} pushes weren't backed-out by a sheriff and were classify as GOOD."
+            f"{len(good_non_backedout_pushes)} out of {len(pushes)} pushes weren't backed-out by a sheriff and were classified as GOOD."
         )
         self.line(
-            f"{len(unknown_pushes)} out of {len(pushes)} pushes were classify as UNKNOWN."
+            f"{len(unknown_pushes)} out of {len(pushes)} pushes were classified as UNKNOWN."
         )
 
 

--- a/mozci/console/commands/push.py
+++ b/mozci/console/commands/push.py
@@ -225,10 +225,12 @@ class ClassifyEvalCommand(Command):
                     continue
             else:
                 try:
-                    index = f"project.mozci.classification.{branch}.push.{push.id}"
-                    task = Task.create(index=index)
+                    index = f"project.mozci.classification.{branch}.revision.{push.rev}"
+                    task = Task.create(index=index, use_community=True)
 
-                    artifact = task.get_artifact("public/classification.json")
+                    artifact = task.get_artifact(
+                        "public/classification.json", use_community=True
+                    )
                     classification = artifact["push"]["classification"]
                 except Exception:
                     classification_failed.append(push)
@@ -247,9 +249,10 @@ class ClassifyEvalCommand(Command):
             else:
                 unknown_pushes.append(push)
 
-        self.line(
-            f"<error>Failed to fetch or recalculate classification for {len(classification_failed)} out of {len(pushes)} pushes.</error>"
-        )
+        if classification_failed:
+            self.line(
+                f"<error>Failed to fetch or recalculate classification for {len(classification_failed)} out of {len(pushes)} pushes.</error>"
+            )
         self.line(
             f"{len(bad_backedout_pushes)} out of {len(pushes)} pushes were backed-out by a sheriff and were classify as BAD."
         )

--- a/mozci/console/commands/push.py
+++ b/mozci/console/commands/push.py
@@ -28,6 +28,37 @@ class PushTasksCommand(Command):
         self.line(tabulate(table, headers=["Label", "Result"]))
 
 
+def classify_commands_pushes(branch, from_date, to_date, rev):
+    if not (bool(rev) ^ bool(from_date or to_date)):
+        return (
+            [],
+            "You must either provide a single push revision with --rev or define --from-date AND --to-date options to classify a range of pushes.",
+        )
+
+    if rev:
+        pushes = [Push(rev, branch)]
+    else:
+        if not from_date or not to_date:
+            return (
+                [],
+                "You must provide --from-date AND --to-date options to classify a range of pushes.",
+            )
+
+        try:
+            datetime.datetime.strptime(from_date, "%Y-%m-%d")
+        except ValueError:
+            return [], "Provided --from-date should be a date in yyyy-mm-dd format."
+
+        try:
+            datetime.datetime.strptime(to_date, "%Y-%m-%d")
+        except ValueError:
+            return [], "Provided --to-date should be a date in yyyy-mm-dd format."
+
+        pushes = make_push_objects(from_date=from_date, to_date=to_date, branch=branch)
+
+    return pushes, None
+
+
 class ClassifyCommand(Command):
     """
     Display the classification for a given push (or a range of pushes) as GOOD, BAD or UNKNOWN.
@@ -45,43 +76,13 @@ class ClassifyCommand(Command):
 
     def handle(self):
         branch = self.argument("branch")
-        from_date = self.option("from-date")
-        to_date = self.option("to-date")
 
-        if not (bool(self.option("rev")) ^ bool(from_date or to_date)):
-            self.line(
-                "<error>You must either provide a single push revision with --rev or define --from-date AND --to-date options to classify a range of pushes.</error>"
-            )
+        pushes, error = classify_commands_pushes(
+            branch, self.option("from-date"), self.option("to-date"), self.option("rev")
+        )
+        if error:
+            self.line(f"<error>{error}</error>")
             return
-
-        if self.option("rev"):
-            pushes = [Push(self.option("rev"), branch)]
-        else:
-            if not from_date or not to_date:
-                self.line(
-                    "<error>You must provide --from-date AND --to-date options to classify a range of pushes.</error>"
-                )
-                return
-
-            try:
-                datetime.datetime.strptime(from_date, "%Y-%m-%d")
-            except ValueError:
-                self.line(
-                    "<error>Provided --from-date should be a date in yyyy-mm-dd format.</error>"
-                )
-                return
-
-            try:
-                datetime.datetime.strptime(to_date, "%Y-%m-%d")
-            except ValueError:
-                self.line(
-                    "<error>Provided --to-date should be a date in yyyy-mm-dd format.</error>"
-                )
-                return
-
-            pushes = make_push_objects(
-                from_date=from_date, to_date=to_date, branch=branch
-            )
 
         try:
             medium_conf = float(self.option("medium-confidence"))
@@ -165,6 +166,43 @@ class ClassifyCommand(Command):
                 )
 
 
+class ClassifyEvalCommand(Command):
+    """
+    Evaluate the classification results for a given push (or a range of pushes) by comparing them with reality.
+
+    classify-eval
+        {branch=mozilla-central : Branch the push belongs to (e.g autoland, try, etc).}
+        {--rev= : Head revision of the push.}
+        {--from-date= : Lower bound of the push range (as a date in yyyy-mm-dd format).}
+        {--to-date= : Upper bound of the push range (as a date in yyyy-mm-dd format).}
+    """
+
+    def handle(self):
+        branch = self.argument("branch")
+
+        pushes, error = classify_commands_pushes(
+            branch, self.option("from-date"), self.option("to-date"), self.option("rev")
+        )
+        if error:
+            self.line(f"<error>{error}</error>")
+            return
+
+        backedout_pushes = []
+        non_backedout_pushes = []
+        for push in pushes:
+            if push.backedout:
+                backedout_pushes.append(push)
+            else:
+                non_backedout_pushes.append(push)
+
+        self.line(
+            f"{len(backedout_pushes)} out of {len(pushes)} pushes were backed-out by a sheriff."
+        )
+        self.line(
+            f"{len(non_backedout_pushes)} out of {len(pushes)} pushes weren't backed-out by a sheriff."
+        )
+
+
 class PushCommands(Command):
     """
     Contains commands that operate on a single push.
@@ -172,7 +210,7 @@ class PushCommands(Command):
     push
     """
 
-    commands = [PushTasksCommand(), ClassifyCommand()]
+    commands = [PushTasksCommand(), ClassifyCommand(), ClassifyEvalCommand()]
 
     def handle(self):
         return self.call("help", self._config.name)

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -15,7 +15,12 @@ from loguru import logger
 from mozci import data
 from mozci.errors import ArtifactNotFound, TaskNotFound
 from mozci.util.memoize import memoized_property
-from mozci.util.taskcluster import find_task_id, get_artifact, list_artifacts
+from mozci.util.taskcluster import (
+    PRODUCTION_TASKCLUSTER_ROOT_URL,
+    find_task_id,
+    get_artifact,
+    list_artifacts,
+)
 
 
 class Status(Enum):
@@ -144,7 +149,7 @@ class Task:
     tier: Optional[int] = field(default=None)
 
     @staticmethod
-    def create(index=None, use_community=False, **kwargs):
+    def create(index=None, root_url=PRODUCTION_TASKCLUSTER_ROOT_URL, **kwargs):
         """Factory method to create a new Task instance.
 
         One of ``index`` or ``id`` must be specified.
@@ -159,7 +164,7 @@ class Task:
         """
         if index and "id" not in kwargs:
             try:
-                kwargs["id"] = find_task_id(index, use_community=use_community)
+                kwargs["id"] = find_task_id(index, root_url=root_url)
             except requests.exceptions.HTTPError as e:
                 label = kwargs.get("label", "unknown label")
                 raise TaskNotFound(id=index, label=label) from e
@@ -177,7 +182,7 @@ class Task:
         """List the artifacts that were uploaded by this task."""
         return [artifact["name"] for artifact in list_artifacts(self.id)]
 
-    def get_artifact(self, path, use_community=False):
+    def get_artifact(self, path, root_url=PRODUCTION_TASKCLUSTER_ROOT_URL):
         """Downloads and returns the content of an artifact.
 
         Args:
@@ -194,7 +199,7 @@ class Task:
                 artifact does not exist.
         """
         try:
-            data = get_artifact(self.id, path, use_community=use_community)
+            data = get_artifact(self.id, path, root_url=root_url)
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 404:
                 raise ArtifactNotFound(path, self.id, self.label) from e

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -144,7 +144,7 @@ class Task:
     tier: Optional[int] = field(default=None)
 
     @staticmethod
-    def create(index=None, **kwargs):
+    def create(index=None, use_community=False, **kwargs):
         """Factory method to create a new Task instance.
 
         One of ``index`` or ``id`` must be specified.
@@ -159,7 +159,7 @@ class Task:
         """
         if index and "id" not in kwargs:
             try:
-                kwargs["id"] = find_task_id(index)
+                kwargs["id"] = find_task_id(index, use_community=use_community)
             except requests.exceptions.HTTPError as e:
                 label = kwargs.get("label", "unknown label")
                 raise TaskNotFound(id=index, label=label) from e
@@ -177,7 +177,7 @@ class Task:
         """List the artifacts that were uploaded by this task."""
         return [artifact["name"] for artifact in list_artifacts(self.id)]
 
-    def get_artifact(self, path):
+    def get_artifact(self, path, use_community=False):
         """Downloads and returns the content of an artifact.
 
         Args:
@@ -194,7 +194,7 @@ class Task:
                 artifact does not exist.
         """
         try:
-            data = get_artifact(self.id, path)
+            data = get_artifact(self.id, path, use_community=use_community)
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 404:
                 raise ArtifactNotFound(path, self.id, self.label) from e

--- a/mozci/util/taskcluster.py
+++ b/mozci/util/taskcluster.py
@@ -38,18 +38,16 @@ def _handle_artifact(path, response):
     return response
 
 
-def get_artifact_url(task_id, path, use_community=False):
+def get_artifact_url(task_id, path, root_url=PRODUCTION_TASKCLUSTER_ROOT_URL):
     return liburls.api(
-        PRODUCTION_TASKCLUSTER_ROOT_URL
-        if not use_community
-        else COMMUNITY_TASKCLUSTER_ROOT_URL,
+        root_url,
         "queue",
         "v1",
         f"task/{task_id}/artifacts/{path}",
     )
 
 
-def get_artifact(task_id, path, use_community=False):
+def get_artifact(task_id, path, root_url=PRODUCTION_TASKCLUSTER_ROOT_URL):
     """
     Returns the artifact with the given path for the given task id.
 
@@ -58,7 +56,7 @@ def get_artifact(task_id, path, use_community=False):
     dict) is returned.
     For other types of content, a file-like object is returned.
     """
-    response = _do_request(get_artifact_url(task_id, path, use_community=use_community))
+    response = _do_request(get_artifact_url(task_id, path, root_url=root_url))
 
     return _handle_artifact(path, response)
 
@@ -67,19 +65,17 @@ def list_artifacts(task_id):
     return queue.listLatestArtifacts(task_id)["artifacts"]
 
 
-def get_index_url(index_path, use_community=False):
+def get_index_url(index_path, root_url=PRODUCTION_TASKCLUSTER_ROOT_URL):
     return liburls.api(
-        PRODUCTION_TASKCLUSTER_ROOT_URL
-        if not use_community
-        else COMMUNITY_TASKCLUSTER_ROOT_URL,
+        root_url,
         "index",
         "v1",
         f"task/{index_path}",
     )
 
 
-def find_task_id(index_path, use_proxy=False, use_community=False):
-    response = _do_request(get_index_url(index_path, use_community=use_community))
+def find_task_id(index_path, use_proxy=False, root_url=PRODUCTION_TASKCLUSTER_ROOT_URL):
+    response = _do_request(get_index_url(index_path, root_url=root_url))
     return response.json()["taskId"]
 
 


### PR DESCRIPTION
As we can't retrieve classification results from artifacts for now, the command only displays pushes that were backed-out or not.

### TODO:
- [x] Retrieve classification results
- [x] Output statistics

Closes #553 