### PR TITLE
Use task errors when listing failing tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ venv.bak/
 
 # Editor stuff:
 .vim
+
+# Classification results
+classify_output_*.json

--- a/mozci/data/sources/artifact/__init__.py
+++ b/mozci/data/sources/artifact/__init__.py
@@ -79,4 +79,4 @@ class ErrorSummarySource(DataSource):
     def run_test_task_errors(self, task):
         if task.id not in self.TASK_ERRORS:
             self._load_errorsummary(task.id)
-        return self.TASK_ERRORS.pop(task.id, {})
+        return self.TASK_ERRORS.pop(task.id, [])

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -259,8 +259,10 @@ class TestTask(Task):
                     "test_task_groups", branch=push.branch, rev=push.rev, task=self
                 ).items()
             ]
+            self._errors = data.handler.get("test_task_errors", task=self)
         else:
             self._results = []
+            self._errors = []
 
         # Apply WPT workaround, needed at least until bug 1632546 is fixed.
         if self.is_wpt:

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -413,12 +413,14 @@ class GroupSummary(RunnableSummary):
     @memoized_property
     def failing_tasks(self):
         # List all tasks with some test results failing for that group
+        # or with misbehaving tasks (early failures or missing results)
         return [
             task
             for task in self.tasks
             if any(
                 not result.ok and result.group == self.name for result in task.results
             )
+            or len(task.errors) > 0
         ]
 
     @memoized_property


### PR DESCRIPTION
Closes #563 

The current `failing_tasks` algorithm only uses completed tasks with results: this totally skips the failed tasks with errors.

I made a bunch of changes here:
- `failing_tasks` now also checks if the task has any error
- task errors are loaded at the same time than task results
- missing test results are marked as failed
- fixed a bug on the task errors output (validx was not OK with current implementation)