### PR TITLE
Use Taskcluster secret as configuration source to use cache

### DIFF
--- a/mozci/configuration.py
+++ b/mozci/configuration.py
@@ -82,6 +82,10 @@ class CustomCacheManager(CacheManager):
         super_config.setdefault("stores", {"null": {"driver": "null"}})
         super(CustomCacheManager, self).__init__(super_config)
 
+        for store, conf in self._config["stores"].items():
+            if store != "null":
+                logger.debug(f"Active cache store {store} with conf {conf}")
+
         self.extend("null", lambda driver: NullStore())
         self.extend("seeded-file", SeededFileStore)
         self.extend(

--- a/mozci/util/cache_stores.py
+++ b/mozci/util/cache_stores.py
@@ -14,6 +14,7 @@ from cachy.stores import FileStore, NullStore  # noqa
 from loguru import logger
 
 from mozci.util.req import get_session
+from mozci.util.taskcluster import get_taskcluster_options
 
 
 def extract_tar_zst(path, dest):
@@ -124,25 +125,6 @@ class RenewingFileStore(FileStore):
 
         self.put(key, value, self.retention)
         return value
-
-
-def get_taskcluster_options():
-    """
-    Helper to get the Taskcluster setup options
-    according to current environment (local or Taskcluster)
-    """
-    options = taskcluster.optionsFromEnvironment()
-    proxy_url = os.environ.get("TASKCLUSTER_PROXY_URL")
-
-    if proxy_url is not None:
-        # Always use proxy url when available
-        options["rootUrl"] = proxy_url
-
-    if "rootUrl" not in options:
-        # Always have a value in root url
-        options["rootUrl"] = "https://community-tc.services.mozilla.com"
-
-    return options
 
 
 def get_s3_credentials(bucket, prefix):

--- a/mozci/util/taskcluster.py
+++ b/mozci/util/taskcluster.py
@@ -96,14 +96,20 @@ def get_tasks_in_group(group_id):
     return tasks
 
 
-def get_proxy_queue():
-    """Configure taskcluster queue through internal proxy"""
+def get_taskcluster_options():
+    """
+    Helper to get the Taskcluster setup options
+    according to current environment (local or Taskcluster)
+    """
+    options = taskcluster.optionsFromEnvironment()
+    proxy_url = os.environ.get("TASKCLUSTER_PROXY_URL")
 
-    root_url = os.environ.get("TASKCLUSTER_PROXY_URL")
-    if not root_url:
-        raise Exception("Missing taskcluster proxy")
-    return taskcluster.Queue(
-        {
-            "rootUrl": root_url,
-        }
-    )
+    if proxy_url is not None:
+        # Always use proxy url when available
+        options["rootUrl"] = proxy_url
+
+    if "rootUrl" not in options:
+        # Always have a value in root url
+        options["rootUrl"] = "https://community-tc.services.mozilla.com"
+
+    return options


### PR DESCRIPTION
Closes #572 & #564 

A few things are happening here:
1. a docker-worker cache is enabled for children tasks (see scope request https://github.com/mozilla/community-tc-config/pull/455 )
2.  in order to use that cache, we need to configure mozci in Taskcluster. The best way to do that is to use a Taskcluster secret
3. so the `Configuration` class uses an optional environment variable `TASKCLUSTER_CONFIG_SECRET` that is also set on the children tasks (the decision task does not need configuration).
4. then it's fairly immediate: any child task will use that configuration and merge it as it would from a file. So if we set the correct configuration in `project/mozci/testing` the shared cache will be used

Maybe we should add some debugging output regarding the cache configuration to make sure we are using correctly ?