### PR TITLE
Explicit scope attribution for the cache

### DIFF
--- a/mozci/console/commands/decision.py
+++ b/mozci/console/commands/decision.py
@@ -73,7 +73,10 @@ class DecisionCommand(Command):
             "dependencies": [
                 self.current_task["id"],
             ],
-            "scopes": ["docker-worker:cache:mozci-classifications-testing"],
+            "scopes": [
+                "docker-worker:cache:mozci-classifications-testing",
+                "secrets:get:project/mozci/testing",
+            ],
             "metadata": {
                 "name": f"mozci classify {push.branch}@{push.rev}",
                 "description": "mozci classification task",

--- a/mozci/console/commands/decision.py
+++ b/mozci/console/commands/decision.py
@@ -73,6 +73,7 @@ class DecisionCommand(Command):
             "dependencies": [
                 self.current_task["id"],
             ],
+            "scopes": ["docker-worker:cache:mozci-classifications-testing"],
             "metadata": {
                 "name": f"mozci classify {push.branch}@{push.rev}",
                 "description": "mozci classification task",


### PR DESCRIPTION
mozci classification tasks are currently failing due to a missing scope to attach the cache ([example](https://community-tc.services.mozilla.com/tasks/dpW2t0hFT42fMPSb-qTfOg/runs/0/logs/public/logs/live.log)).

This MR simply adds the relevant scope that is set on the [hook role](https://community-tc.services.mozilla.com/auth/roles/hook-id%3Aproject-mozci%2Fdecision-task-testing). I thought this scope would be validated on task creation