### PR TITLE
Enable Taskcluster proxy on classifications tasks

### DIFF
--- a/mozci/console/commands/decision.py
+++ b/mozci/console/commands/decision.py
@@ -73,9 +73,6 @@ class DecisionCommand(Command):
             "dependencies": [
                 self.current_task["id"],
             ],
-            "features": {
-                "taskclusterProxy": True,
-            },
             "scopes": [
                 "docker-worker:cache:mozci-classifications-testing",
                 "secrets:get:project/mozci/testing",
@@ -91,6 +88,9 @@ class DecisionCommand(Command):
                 "image": self.current_task["payload"]["image"],
                 "env": {
                     "TASKCLUSTER_CONFIG_SECRET": "project/mozci/testing",
+                },
+                "features": {
+                    "taskclusterProxy": True,
                 },
                 "command": [
                     "push",

--- a/mozci/console/commands/decision.py
+++ b/mozci/console/commands/decision.py
@@ -73,6 +73,9 @@ class DecisionCommand(Command):
             "dependencies": [
                 self.current_task["id"],
             ],
+            "features": {
+                "taskclusterProxy": True,
+            },
             "scopes": [
                 "docker-worker:cache:mozci-classifications-testing",
                 "secrets:get:project/mozci/testing",


### PR DESCRIPTION
Classification tasks are starting again but failing to fetch the requested secrets as they reach the TC instance through the external interface, and not the proxy.

Example : https://community-tc.services.mozilla.com/tasks/ZCjT6bAJSl6azfaBd4HAqg/runs/0/logs/public/logs/live.log