### PR TITLE
Fix intermittent groups having an empty list of tasks associated to them

### DIFF
--- a/mozci/push.py
+++ b/mozci/push.py
@@ -1037,14 +1037,17 @@ class Push:
         # - if a group is failing in all tasks, then it is a "cross-config" failure
         # - if a group is failing only in some tasks but not all, then it is not a "cross-config" failure
         all_groups = self.group_summaries.values()
-        failing_groups = [g for g in all_groups if g.status == Status.FAIL]
         groups_cross_config_failure = {
-            g.name for g in failing_groups if g.is_cross_config_failure
+            g.name for g in all_groups if g.is_cross_config_failure
         }
         groups_non_cross_config_failure = {
-            g.name for g in failing_groups if not g.is_cross_config_failure
+            g.name
+            for g in all_groups
+            if g.status != Status.PASS and not g.is_cross_config_failure
         }
-        groups_failing_in_the_push = {g.name for g in failing_groups}
+        groups_failing_in_the_push = {
+            g.name for g in all_groups if g.status != Status.PASS
+        }
         groups_no_confidence = {
             g.name
             for g in all_groups

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -1037,15 +1037,14 @@ class Push:
         # - if a group is failing in all tasks, then it is a "cross-config" failure
         # - if a group is failing only in some tasks but not all, then it is not a "cross-config" failure
         all_groups = self.group_summaries.values()
+        failing_groups = [g for g in all_groups if g.status == Status.FAIL]
         groups_cross_config_failure = {
-            g.name for g in all_groups if g.is_cross_config_failure
+            g.name for g in failing_groups if g.is_cross_config_failure
         }
         groups_non_cross_config_failure = {
-            g.name for g in all_groups if not g.is_cross_config_failure
+            g.name for g in failing_groups if not g.is_cross_config_failure
         }
-        groups_failing_in_the_push = {
-            g.name for g in all_groups if g.status == Status.FAIL
-        }
+        groups_failing_in_the_push = {g.name for g in failing_groups}
         groups_no_confidence = {
             g.name
             for g in all_groups

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -49,6 +49,8 @@ SCHEDULES_EXTRACT = {
     ],
 }
 
+# group1, status = INTERMITTENT
+# group2, group3, group4, group5, status = FAIL
 GROUP_SUMMARIES_DEFAULT = {
     group.name: group
     for group in [
@@ -62,7 +64,19 @@ GROUP_SUMMARIES_DEFAULT = {
                     _results=[GroupResult(group=f"group{i}", ok=False)],
                 )
                 for j in range(1, 4)
-            ],
+            ]
+            + (
+                [
+                    Task.create(
+                        id=4,
+                        label="test-task1",
+                        result="passed",
+                        _results=[GroupResult(group="group1", ok=True)],
+                    )
+                ]
+                if i == 1
+                else []
+            ),
         )
         for i in range(1, 6)
     ]
@@ -78,7 +92,18 @@ def make_tasks(group_id):
             _results=[GroupResult(group=group_id, ok=False)],
         )
         for j in range(1, 4)
-    ]
+    ] + (
+        [
+            TestTask(
+                id=4,
+                label="test-task1",
+                result="passed",
+                _results=[GroupResult(group="group1", ok=True)],
+            )
+        ]
+        if group_id == 1
+        else []
+    )
 
 
 @pytest.fixture
@@ -913,6 +938,9 @@ def generate_mocks(
         Push, "get_likely_regressions", mock_return_get_likely_regressions
     )
 
+    for g in GROUP_SUMMARIES_DEFAULT.values():
+        print(g.name)
+        print(g.status)
     push.group_summaries = GROUP_SUMMARIES_DEFAULT
     for index, group in enumerate(push.group_summaries.values()):
         group.is_cross_config_failure = cross_config_values[index]

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -938,9 +938,6 @@ def generate_mocks(
         Push, "get_likely_regressions", mock_return_get_likely_regressions
     )
 
-    for g in GROUP_SUMMARIES_DEFAULT.values():
-        print(g.name)
-        print(g.status)
     push.group_summaries = GROUP_SUMMARIES_DEFAULT
     for index, group in enumerate(push.group_summaries.values()):
         group.is_cross_config_failure = cross_config_values[index]

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -13,7 +13,7 @@ from mozci.errors import (
     SourcesNotFound,
 )
 from mozci.push import Push, PushStatus, Regressions
-from mozci.task import GroupResult, GroupSummary, Task, TestTask
+from mozci.task import GroupResult, GroupSummary, Status, Task, TestTask
 from mozci.util.hgmo import HgRev
 from mozci.util.taskcluster import (
     PRODUCTION_TASKCLUSTER_ROOT_URL,
@@ -49,8 +49,8 @@ SCHEDULES_EXTRACT = {
     ],
 }
 
-# group1, status = INTERMITTENT
-# group2, group3, group4, group5, status = FAIL
+NUMBER_OF_DEFAULT_GROUPS = 5
+NUMBER_OF_INTERMITTENT_GROUPS_IN_DEFAULT = 2
 GROUP_SUMMARIES_DEFAULT = {
     group.name: group
     for group in [
@@ -71,16 +71,32 @@ GROUP_SUMMARIES_DEFAULT = {
                         id=4,
                         label="test-task1",
                         result="passed",
-                        _results=[GroupResult(group="group1", ok=True)],
+                        _results=[GroupResult(group=f"group{i}", ok=True)],
                     )
                 ]
-                if i == 1
+                if i <= NUMBER_OF_INTERMITTENT_GROUPS_IN_DEFAULT
                 else []
             ),
         )
-        for i in range(1, 6)
+        for i in range(1, NUMBER_OF_DEFAULT_GROUPS + 1)
     ]
 }
+
+
+def test_group_summaries_default_status():
+    assert {
+        **{
+            f"group{i}": Status.INTERMITTENT
+            for i in range(1, NUMBER_OF_INTERMITTENT_GROUPS_IN_DEFAULT + 1)
+        },
+        **{
+            f"group{i}": Status.FAIL
+            for i in range(
+                NUMBER_OF_INTERMITTENT_GROUPS_IN_DEFAULT + 1,
+                NUMBER_OF_DEFAULT_GROUPS + 1,
+            )
+        },
+    } == {g.name: g.status for g in GROUP_SUMMARIES_DEFAULT.values()}
 
 
 def make_tasks(group_id):
@@ -92,18 +108,7 @@ def make_tasks(group_id):
             _results=[GroupResult(group=group_id, ok=False)],
         )
         for j in range(1, 4)
-    ] + (
-        [
-            TestTask(
-                id=4,
-                label="test-task1",
-                result="passed",
-                _results=[GroupResult(group="group1", ok=True)],
-            )
-        ]
-        if group_id == 1
-        else []
-    )
+    ]
 
 
 @pytest.fixture


### PR DESCRIPTION
While working on the groups CSV output that Bastien asked for [here](https://github.com/mozilla/mozci/issues/563#issuecomment-990738797), I might have found a fix for the empty lists of tasks associated with some intermittent groups.

Turns out, we were using groups marked as PASSING as well as the ones marked as FAILING in `groups_cross_config_failure` and `groups_non_cross_config_failure`.

By looking at the logs from the `classify` command (tested on push `mozilla-central/4185629111d323484d1f74a667d57145616203b7`), we can see that with the previous implementation we had a lot more of intermittent groups than failing ones:
```
11:33:36.890 | DEBUG    |      mozci.push:1033 - Got 91 groups with high confidence
11:33:36.891 | DEBUG    |      mozci.push:1034 - Got 734 groups with low confidence
11:33:37.457 | DEBUG    |      mozci.push:1054 - Got 28 groups with cross-config failures
11:33:37.457 | DEBUG    |      mozci.push:1057 - Got 2661 groups with no cross-config failures
11:33:37.458 | DEBUG    |      mozci.push:1060 - Got 28 groups failing in the push
11:33:37.458 | DEBUG    |      mozci.push:1063 - Got 1807 groups without bugbug confidence
11:33:37.458 | DEBUG    |      mozci.push:1072 - Got 0 real failures
11:33:37.458 | DEBUG    |      mozci.push:1080 - Got 2527 intermittent failures
11:33:37.459 | DEBUG    |      mozci.push:1086 - Got 28 unknown failures
```

With the fixed implementation real(0)+intermittent(0)+unknown(28) groups counts properly equal to the failing ones count(28):
```
09:47:14.502 | DEBUG    |      mozci.push:1034 - Got 91 groups with high confidence
09:47:14.503 | DEBUG    |      mozci.push:1035 - Got 734 groups with low confidence
09:47:14.810 | DEBUG    |      mozci.push:1055 - Got 28 groups with cross-config failures
09:47:14.810 | DEBUG    |      mozci.push:1058 - Got 0 groups with no cross-config failures
09:47:14.810 | DEBUG    |      mozci.push:1061 - Got 28 groups failing in the push
09:47:14.810 | DEBUG    |      mozci.push:1064 - Got 1807 groups without bugbug confidence
09:47:14.810 | DEBUG    |      mozci.push:1073 - Got 0 real failures
09:47:14.811 | DEBUG    |      mozci.push:1081 - Got 0 intermittent failures
09:47:14.811 | DEBUG    |      mozci.push:1087 - Got 28 unknown failures
```

**In the end, the only issue there, might just be that we were classifying almost all passing groups as intermittent instead of just ignoring them.**

Closes #563 