### PR TITLE
Enhance command push classify-eval

### DIFF
--- a/mozci/console/commands/push.py
+++ b/mozci/console/commands/push.py
@@ -255,7 +255,10 @@ class ClassifyEvalCommand(Command):
                     classification, _ = push.classify(
                         confidence_medium=medium_conf, confidence_high=high_conf
                     )
-                except Exception:
+                except Exception as e:
+                    self.line(
+                        f"classification failed on {branch} {push.rev}: {e}</error>"
+                    )
                     classification_failed.append(push)
                     continue
             else:
@@ -270,7 +273,10 @@ class ClassifyEvalCommand(Command):
                         root_url=COMMUNITY_TASKCLUSTER_ROOT_URL,
                     )
                     classification = artifact["push"]["classification"]
-                except Exception:
+                except Exception as e:
+                    self.line(
+                        f"<error>fetch failed on {branch} {push.rev}: {e}</error>"
+                    )
                     classification_failed.append(push)
                     continue
 

--- a/mozci/console/commands/push.py
+++ b/mozci/console/commands/push.py
@@ -316,7 +316,6 @@ class ClassifyEvalCommand(Command):
                 writer = csv.DictWriter(
                     csvfile,
                     fieldnames=[
-                        "push",
                         "revision",
                         "date",
                         "classification",
@@ -339,7 +338,6 @@ class ClassifyEvalCommand(Command):
         error = self.errors.get(push)
 
         return {
-            "push": push.id,
             "revision": push.rev,
             "date": push.date,
             "classification": classification or "error",


### PR DESCRIPTION
- Add more logging:
   - around errors
   - on recalculate normal flow
   - on Taskcluster task fetch normal flow
- Refactor the output & inner triage of push classification so it can generate both:
   - same summary output
   - a CSV output with more detailed informations (tracking exceptions)