### PR TITLE
Speedup classification by avoiding to load each push information

### DIFF
--- a/mozci/console/commands/push.py
+++ b/mozci/console/commands/push.py
@@ -253,11 +253,10 @@ class ClassifyEvalCommand(Command):
         self.errors = {}
         self.classifications = {}
         for push in self.pushes:
-            classification = None
             if self.option("recalculate"):
                 progress.set_message(f"Calc. {branch} {push.id}")
                 try:
-                    classification, _ = push.classify(
+                    self.classifications[push], _ = push.classify(
                         confidence_medium=medium_conf, confidence_high=high_conf
                     )
                 except Exception as e:
@@ -297,6 +296,7 @@ class ClassifyEvalCommand(Command):
 
         # Conclude the progress bar
         progress.finish()
+        print("\n")
 
         if self.errors:
             self.line(

--- a/mozci/console/commands/push.py
+++ b/mozci/console/commands/push.py
@@ -204,6 +204,7 @@ class ClassifyEvalCommand(Command):
         branch = self.argument("branch")
 
         try:
+            self.line("<comment>Loading pushes...</comment>")
             self.pushes = classify_commands_pushes(
                 branch,
                 self.option("from-date"),

--- a/mozci/data/contract.py
+++ b/mozci/data/contract.py
@@ -109,7 +109,19 @@ _contracts: Tuple[Contract, ...] = (
                 {
                     "pushid": v.Int(),
                     "date": v.Int(),
-                    "revs": v.List(v.Str()),
+                    "revs": v.List(
+                        v.Dict(
+                            {
+                                "author": v.Str(),
+                                "branch": v.Str(),
+                                "desc": v.Str(),
+                                "files": v.List(v.Str()),
+                                "node": v.Str(),
+                                "parents": v.List(v.Str()),
+                                "tags": v.List(v.Str()),
+                            }
+                        )
+                    ),
                 }
             )
         ),

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -74,18 +74,20 @@ class Push:
             self._revs = None
             head_revision = revs
             self._bugs = None
-        elif (
-            isinstance(revs, list)
-            and len(revs) > 0
-            and all(map(lambda r: isinstance(r, dict), revs))
-        ):
-            # We should get detailed revision objects here
-            # and get the list of Bugzilla Bug Ids from the description
-            self._bugs = set(
-                itertools.chain(*[parse_bugs(rev.get("desc", "")) for rev in revs])
-            )
+        elif isinstance(revs, list) and len(revs) > 0:
+            if all(map(lambda r: isinstance(r, dict), revs)):
+                # We should get detailed revision objects here
+                # and get the list of Bugzilla Bug Ids from the description
+                self._bugs = set(
+                    itertools.chain(*[parse_bugs(rev.get("desc", "")) for rev in revs])
+                )
 
-            self._revs = [r["node"] for r in revs]
+                self._revs = [r["node"] for r in revs]
+            else:
+                # Support list of changeset IDs
+                self._bugs = None
+                self._revs = revs
+
             head_revision = self._revs[0]
         else:
             raise NotImplementedError(f"Cannot process revisions: {revs}")

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -3,7 +3,6 @@ import concurrent.futures
 import copy
 import itertools
 import math
-import re
 from argparse import Namespace
 from collections import defaultdict
 from dataclasses import dataclass
@@ -41,9 +40,6 @@ when the task did not run on the currently considered push.
 """
 
 FAILURE_CLASSES = ("not classified", "fixed by commit")
-
-
-REGEX_REV = re.compile(r"bug (\d+)", flags=re.IGNORECASE)
 
 
 class PushStatus(Enum):
@@ -656,15 +652,11 @@ class Push:
 
             # Optimization to load child json-pushes data in a single query (up
             # to MAX_DEPTH at a time).
-            # We load ALL available information for the pushes
-            # to avoid later queries for bugs in bustage_fixed_by
             next_id = other.id + 1
             if next_id not in HgRev.JSON_PUSHES_CACHE:
                 depth = max_depth or MAX_DEPTH
                 HgRev.load_json_pushes_between_ids(
-                    self.branch,
-                    other.id,
-                    next_id + depth - i,
+                    self.branch, other.id, next_id + depth - i
                 )
 
             try:

--- a/mozci/util/hgmo.py
+++ b/mozci/util/hgmo.py
@@ -23,6 +23,7 @@ class HgRev:
     JSON_PUSHES_TEMPLATE = (
         JSON_PUSHES_TEMPLATE_BASE + "&startID={push_id_start}&endID={push_id_end}"
     )
+    JSON_PUSHES_FULL_TEMPLATE = JSON_PUSHES_TEMPLATE + "&full=1"
     JSON_PUSHES_BETWEEN_DATES_TEMPLATE = (
         JSON_PUSHES_TEMPLATE_BASE + "&startdate={from_date}&enddate={to_date}"
     )
@@ -55,9 +56,14 @@ class HgRev:
 
     @staticmethod
     def load_json_pushes_between_ids(
-        branch: str, push_id_start: int, push_id_end: int
+        branch: str, push_id_start: int, push_id_end: int, use_full_format=False
     ) -> List[HgPush]:
-        url = HgRev.JSON_PUSHES_TEMPLATE.format(
+        template = (
+            HgRev.JSON_PUSHES_FULL_TEMPLATE
+            if use_full_format
+            else HgRev.JSON_PUSHES_TEMPLATE
+        )
+        url = template.format(
             push_id_start=push_id_start,
             push_id_end=push_id_end,
             branch=f"integration/{branch}" if branch == "autoland" else branch,

--- a/mozci/util/hgmo.py
+++ b/mozci/util/hgmo.py
@@ -19,11 +19,10 @@ class HgRev:
     AUTOMATION_RELEVANCE_TEMPLATE = (
         BASE_URL + "{branch}/json-automationrelevance/{rev}?backouts=1"
     )
-    JSON_PUSHES_TEMPLATE_BASE = BASE_URL + "{branch}/json-pushes?version=2"
+    JSON_PUSHES_TEMPLATE_BASE = BASE_URL + "{branch}/json-pushes?version=2&full=1"
     JSON_PUSHES_TEMPLATE = (
         JSON_PUSHES_TEMPLATE_BASE + "&startID={push_id_start}&endID={push_id_end}"
     )
-    JSON_PUSHES_FULL_TEMPLATE = JSON_PUSHES_TEMPLATE + "&full=1"
     JSON_PUSHES_BETWEEN_DATES_TEMPLATE = (
         JSON_PUSHES_TEMPLATE_BASE + "&startdate={from_date}&enddate={to_date}"
     )
@@ -56,14 +55,9 @@ class HgRev:
 
     @staticmethod
     def load_json_pushes_between_ids(
-        branch: str, push_id_start: int, push_id_end: int, use_full_format=False
+        branch: str, push_id_start: int, push_id_end: int
     ) -> List[HgPush]:
-        template = (
-            HgRev.JSON_PUSHES_FULL_TEMPLATE
-            if use_full_format
-            else HgRev.JSON_PUSHES_TEMPLATE
-        )
-        url = template.format(
+        url = HgRev.JSON_PUSHES_TEMPLATE.format(
             push_id_start=push_id_start,
             push_id_end=push_id_end,
             branch=f"integration/{branch}" if branch == "autoland" else branch,

--- a/mozci/util/hgmo.py
+++ b/mozci/util/hgmo.py
@@ -13,6 +13,8 @@ from mozci.util.req import get_session
 
 HgPush = NewType("HgPush", Dict[str, Any])
 
+# This code is ported from HGMO hgcustom extension
+# https://hg.mozilla.org/hgcustom/version-control-tools/file/9822fcf4b1178d219b7d7a386dda02a11facf55b/pylib/mozautomation/mozautomation/commitparser.py#l97
 RE_SOURCE_REPO = re.compile(r"^Source-Repo: (https?:\/\/.*)$", re.MULTILINE)
 BUG_RE = re.compile(
     r"""# bug followed by any sequence of numbers, or

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,7 +109,7 @@ def create_push(monkeypatch, responses):
         push._id = push_id
         push_rev_to_id[rev] = push_id
         push.backedoutby = None
-        push.bugs = {push_id}
+        push._bugs = {push_id}
         push.tasks = []
         push._revs = [push.rev]
         push.is_manifest_level = False

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -152,7 +152,9 @@ def test_create_push(responses):
             json={
                 "pushes": {
                     "123": {
-                        "changesets": ["123456"],
+                        "changesets": [
+                            {"node": "123456", "desc": "Bug 567890 - Fix something bad"}
+                        ],
                         "date": 1213174092,
                         "user": "user@example.org",
                     },
@@ -519,7 +521,7 @@ def test_push_parent_on_autoland(responses):
         json={
             "pushes": {
                 "122": {
-                    "changesets": ["b" * 40],
+                    "changesets": [{"node": "b" * 40}],
                     "date": 1213174092,
                     "user": "user@example.org",
                 },
@@ -533,6 +535,7 @@ def test_push_parent_on_autoland(responses):
     parent = p1.parent
 
     assert parent.id == 122
+    assert parent.rev == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 
 
 def test_push_parent_on_try(responses, create_changesets):
@@ -842,10 +845,19 @@ def test_iterate_children(responses):
 
     responses.add(
         responses.GET,
-        f"https://hg.mozilla.org/{branch}/json-pushes?version=2&startID={push_id}&endID={push_id+depth+1}",
+        f"https://hg.mozilla.org/{branch}/json-pushes?version=2&full=1&startID={push_id}&endID={push_id+depth+1}",
         json={
             "pushes": {
-                push_id + i: {"changesets": [chr(ord("a") + i) * 40], "date": 1}
+                push_id
+                + i: {
+                    "changesets": [
+                        {
+                            "node": chr(ord("a") + i) * 40,
+                            "desc": "A nice description about Bug 1234567",
+                        }
+                    ],
+                    "date": 1,
+                }
                 for i in range(1, depth + 2)
             }
         },
@@ -878,10 +890,19 @@ def test_iterate_parents(responses):
 
     responses.add(
         responses.GET,
-        f"https://hg.mozilla.org/{branch}/json-pushes?version=2&startID={push_id-2-depth}&endID={push_id-1}",
+        f"https://hg.mozilla.org/{branch}/json-pushes?version=2&full=1&startID={push_id-2-depth}&endID={push_id-1}",
         json={
             "pushes": {
-                push_id - i: {"changesets": [chr(ord("a") + i) * 40], "date": 1}
+                push_id
+                - i: {
+                    "changesets": [
+                        {
+                            "node": chr(ord("a") + i) * 40,
+                            "desc": "A nice description about Bug 1234567",
+                        }
+                    ],
+                    "date": 1,
+                }
                 for i in range(1, depth + 2)
             }
         },

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -270,7 +270,7 @@ def test_failure_on_bustage_fix(create_pushes):
             classification="not classified",
         ),
     ]
-    p[i].bugs = {123}
+    p[i]._bugs = {123}
     p[i + 1].tasks = []
     p[i + 1].backedoutby = p[i + 3].rev
     p[i + 2].tasks = [
@@ -286,7 +286,7 @@ def test_failure_on_bustage_fix(create_pushes):
             result="passed",
         ),
     ]
-    p[i + 2].bugs = {123}
+    p[i + 2]._bugs = {123}
 
     assert p[i].get_regressions("label") == {"test_for_detecting_bustage_fix": 0}
     assert p[i + 1].get_regressions("label") == {"test": 2}
@@ -539,9 +539,9 @@ def test_failed_and_bustage_fixed(create_pushes):
             result="passed",
         ),
     ]
-    p[i].bugs = {123}
+    p[i]._bugs = {123}
     p[i + 1].tasks = [create_task(id=fake_id(1), label="test-prova1", result="passed")]
-    p[i + 1].bugs = {123}
+    p[i + 1]._bugs = {123}
 
     assert p[i].get_regressions("label") == {"test-prova1": 0}
 
@@ -568,9 +568,9 @@ def test_failed_and_bustage_fixed_intermittently(create_pushes):
             result="passed",
         ),
     ]
-    p[i].bugs = {123}
+    p[i]._bugs = {123}
     p[i + 1].tasks = [create_task(id=fake_id(1), label="test-prova", result="passed")]
-    p[i + 1].bugs = {123}
+    p[i + 1]._bugs = {123}
 
     assert p[i].get_regressions("label") == {"test-prova": 0}
 
@@ -592,8 +592,8 @@ def test_failed_with_child_push_fixing_same_bug(create_pushes):
             classification="not classified",
         )
     ]
-    p[i].bugs = {123}
-    p[i + 1].bugs = {123}
+    p[i]._bugs = {123}
+    p[i + 1]._bugs = {123}
 
     assert p[i].get_regressions("label") == {}
 
@@ -640,7 +640,7 @@ def test_failed_with_child_push_still_failing_fixing_same_bug(create_pushes):
             classification="intermittent",
         ),
     ]
-    p[i].bugs = {123}
+    p[i]._bugs = {123}
     p[i + 1].tasks = [
         create_task(
             id=fake_id(1),
@@ -659,7 +659,7 @@ def test_failed_with_child_push_still_failing_fixing_same_bug(create_pushes):
             result="passed",
         ),
     ]
-    p[i + 1].bugs = {123}
+    p[i + 1]._bugs = {123}
 
     assert p[i].get_regressions("label") == {}
 
@@ -694,7 +694,7 @@ def test_child_failed_and_bustage_fixed(create_pushes):
     i = 1  # the index of the push we are mainly interested in
 
     p[i - 1].tasks = [create_task(id=fake_id(1), label="test-prova", result="passed")]
-    p[i].bugs = {123}
+    p[i]._bugs = {123}
     p[len(p) - 2].tasks = [
         create_task(
             id=fake_id(1),
@@ -706,7 +706,7 @@ def test_child_failed_and_bustage_fixed(create_pushes):
     p[len(p) - 1].tasks = [
         create_task(id=fake_id(1), label="test-prova", result="passed")
     ]
-    p[len(p) - 1].bugs = {123}
+    p[len(p) - 1]._bugs = {123}
 
     assert p[i].get_regressions("label") == {"test-prova": 10}
 
@@ -1230,7 +1230,7 @@ def test_fixed_by_commit_another_push_possible_classification8(
         )
     ]
     p[i + 4].tasks = [create_task(id=fake_id(1), label="test-failure", result="passed")]
-    p[i + 4].bugs = p[i].bugs
+    p[i + 4]._bugs = p[i].bugs
     p[i + 4]._revs = [p[i + 4].rev, "rev4.2"]
 
     assert p[i].get_regressions("label") == {"test-failure": 0}
@@ -1689,7 +1689,7 @@ def test_fixed_by_commit_another_push_wrong_classification_bustage_fixed(
 
     p[i - 1].tasks = [create_task(id=fake_id(1), label="test-failure", result="passed")]
     p[i].tasks = []
-    p[i].bugs = {123}
+    p[i]._bugs = {123}
     p[i + 1].tasks = [
         create_task(
             id=fake_id(1),
@@ -1700,7 +1700,7 @@ def test_fixed_by_commit_another_push_wrong_classification_bustage_fixed(
         )
     ]
     p[i + 1].backedoutby = p[i + 5].rev
-    p[i + 2].bugs = {123}
+    p[i + 2]._bugs = {123}
 
     assert p[i].get_regressions("label") == {}
     assert p[i + 1].get_regressions("label") == {"test-failure": 1}
@@ -1728,8 +1728,8 @@ def test_fixed_by_commit_another_push_wrong_classification_bustage_fixed2(
 
     p[i - 1].tasks = [create_task(id=fake_id(1), label="test-failure", result="passed")]
     p[i].tasks = []
-    p[i].bugs = {123}
-    p[i + 1].bugs = {123}
+    p[i]._bugs = {123}
+    p[i + 1]._bugs = {123}
     p[i + 2].tasks = [
         create_task(
             id=fake_id(1),


### PR DESCRIPTION
The classification algorithm uses the method `Push.bustage_fixed_by` that trigger an HGMO query for each push, just to get their related Bugzilla bug ID.

This patch uses the `full=1` parameter on HGMO json-pushes method in order to get the description of each revision, and thus their Bugzilla bug ID.

Here is a benchmark running on a random recent autoland revision (command `time mozci push classify-eval --rev=808ac93bdd9847272087ba981173bc877cff0425 --recalculate`)

|            | master    | parse-bug-description |
|------------|-----------|-----------------------|
| cold cache | 1m35,881s | 0m8,662s              |
| warm cache | 0m15,875s | 0m6,002s              |

On another revision which triggers good `time mozci push classify-eval --rev=9c1b66dcaac38344a227cc6cdf3e29272b487c98 --recalculate`, the results are evern better:
- cold cache on master is 2m38,573s
- warm cache on this branch is 0m3,063s

The results stay the same on both branches