### PR TITLE
Fix the cross config logic to consider failures as cross config when they happen on all configurations

### DIFF
--- a/mozci/push.py
+++ b/mozci/push.py
@@ -1094,7 +1094,7 @@ class Push:
         groups_non_cross_config_failure = {
             g.name
             for g in all_groups
-            if g.status != Status.PASS and not g.is_cross_config_failure
+            if g.status != Status.PASS and g.is_cross_config_failure is False
         }
         groups_failing_in_the_push = {
             g.name for g in all_groups if g.status != Status.PASS

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -376,7 +376,7 @@ class GroupSummary(RunnableSummary):
     """Summarizes the overall state of a group (across retriggers)."""
 
     name: str
-    tasks: List[Task]
+    tasks: List[TestTask]
     _durations: Optional[List[float]] = field(default_factory=lambda: [0.0])
 
     def __post_init__(self):
@@ -452,7 +452,7 @@ class GroupSummary(RunnableSummary):
         ]
 
     @memoized_property
-    def is_cross_config_failure(self):
+    def is_cross_config_failure(self) -> Optional[bool]:
         states = [
             result.ok
             for task in self.tasks
@@ -464,9 +464,13 @@ class GroupSummary(RunnableSummary):
         nb_passed = sum(states)  # Number of True booleans in the states list
         nb_failed = nb - nb_passed
 
-        # A group is a cross config failure when it is failing in all tasks, at least two, and not
+        # If the group run on a single task, we don't have enough information to tell.
+        if nb <= 1:
+            return None
+
+        # A group is a cross config failure when it is failing in all tasks and not
         # only in some.
-        return nb > 1 and nb_failed > 0 and nb_passed == 0
+        return nb_failed > 0 and nb_passed == 0
 
 
 @dataclass

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -464,9 +464,9 @@ class GroupSummary(RunnableSummary):
         nb_passed = sum(states)  # Number of True booleans in the states list
         nb_failed = nb - nb_passed
 
-        # A group is a cross config failure when it is failing in all tasks and not
+        # A group is a cross config failure when it is failing in all tasks, at least two, and not
         # only in some.
-        return nb_failed > 0 and nb_passed == 0
+        return nb > 1 and nb_failed > 0 and nb_passed == 0
 
 
 @dataclass

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -464,10 +464,9 @@ class GroupSummary(RunnableSummary):
         nb_passed = sum(states)  # Number of True booleans in the states list
         nb_failed = nb - nb_passed
 
-        # A group is a cross config failure when
-        # - some (not all) tasks have failed
-        # - AND some (not all) tasks have succeeded
-        return nb_passed != nb and nb_failed != nb
+        # A group is a cross config failure when it is failing in all tasks and not
+        # only in some.
+        return nb_failed > 0 and nb_passed == 0
 
 
 @dataclass

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -300,7 +300,7 @@ def test_results_for_incomplete_task(responses):
                     for i in range(1, 11)
                 ],
             ),
-            False,
+            True,
         ),  # All related tasks failed
         (
             GroupSummary(
@@ -318,7 +318,7 @@ def test_results_for_incomplete_task(responses):
                     for i in range(1, 11)
                 ],
             ),
-            True,
+            False,
         ),  # Related tasks both failed and passed
         (
             GroupSummary(

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -299,7 +299,7 @@ def test_results_for_incomplete_task(responses):
                     )
                 ],
             ),
-            False,
+            None,
         ),  # Only one task run and failed
         (
             GroupSummary(

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -293,6 +293,19 @@ def test_results_for_incomplete_task(responses):
                 "group1",
                 [
                     Task.create(
+                        id=1,
+                        label="test-task1",
+                        _results=[GroupResult(group="group1", ok=False), GR_2, GR_3],
+                    )
+                ],
+            ),
+            False,
+        ),  # Only one task run and failed
+        (
+            GroupSummary(
+                "group1",
+                [
+                    Task.create(
                         id=i,
                         label=f"test-task{i}",
                         _results=[GroupResult(group="group1", ok=False), GR_2, GR_3],


### PR DESCRIPTION
The original logic @La0 wrote in #526 was correct, my review comment (https://github.com/mozilla/mozci/pull/526#pullrequestreview-787961109) to change it was wrong.