### PR TITLE
Extend the classify command to perform retriggers on unknown tasks (Fixes #534)

### DIFF
--- a/mozci/push.py
+++ b/mozci/push.py
@@ -1326,6 +1326,13 @@ def make_push_objects(**kwargs):
     return pushes
 
 
+def retrigger(tasks: List[TestTask], repeat_retrigger: int=1) -> None:
+    """Utility function that retrigger a list of task "repeat_retrigger" times."""
+    for task in tasks:
+        for _ in range(0, repeat_retrigger):
+            task.retrigger()
+
+
 def make_summary_objects(from_date, to_date, branch, type):
     """Returns a list of summary objects matching the parameters.
 

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -237,6 +237,7 @@ class Task:
                 "and force not specified.".format(task["tags"]["label"])
             )
             return
+        logger.info("Retriggering task '{}'".format(task["tags"]["label"]))
         create_task(new_task_id, task)
 
     def _should_retrigger(self, task):

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -77,7 +77,7 @@ def test_retrigger_should_retrigger(responses, create_task):
     responses.add(
         responses.GET,
         "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/0",
-        json={"payload": {}, "tags": {"retrigger": "true"}},
+        json={"payload": {}, "tags": {"retrigger": "true", "label": "test_retrigger"}},
         status=200,
     )
 


### PR DESCRIPTION
Fixes #534 

Assumption:
- `regressions.unknown` returns a map of the manifest name mapped to a list of unknown tasks within that manifest.