### PR TITLE
Support TASKCLUSTER_SECRET env variable too

### DIFF
--- a/mozci/configuration.py
+++ b/mozci/configuration.py
@@ -104,7 +104,9 @@ class CustomCacheManager(CacheManager):
 
 class Configuration(Mapping):
     DEFAULT_CONFIG_PATH = Path(user_config_dir("mozci")) / "config.toml"
-    TASKCLUSTER_CONFIG_SECRET = os.environ.get("TASKCLUSTER_CONFIG_SECRET")
+    TASKCLUSTER_CONFIG_SECRET = os.environ.get(
+        "TASKCLUSTER_CONFIG_SECRET"
+    ) or os.environ.get("TASKCLUSTER_SECRET")
     DEFAULTS = {
         "merge": {
             "cache": {"retention": 1440},


### PR DESCRIPTION
This is the more commonly used syntax, and already setup on the monitoring hook