### PR TITLE
Send email notification on bad push evolution

### DIFF
--- a/mozci/data/contract.py
+++ b/mozci/data/contract.py
@@ -197,6 +197,17 @@ _contracts: Tuple[Contract, ...] = (
             )
         ),
     ),
+    Contract(
+        name="push_existing_classification",
+        description="Retrieve the pre-existing classification status of a given push",
+        validate_in=v.Dict(
+            {
+                "branch": v.Str(),
+                "rev": v.Str(),
+            }
+        ),
+        validate_out=v.Str(options=["GOOD", "BAD", "UNKNOWN"]),
+    ),
 )
 
 

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -1265,6 +1265,18 @@ class Push:
             "push_test_selection_data", branch=self.branch, rev=self.rev
         )
 
+    def get_existing_classification(self) -> PushStatus:
+        """Retrieves existing classification from Taskcluster artifacts
+
+        Do not memoize this method as the classification may change every few minutes remotely
+        """
+        existing = data.handler.get(
+            "push_existing_classification", branch=self.branch, rev=self.rev
+        )
+
+        # Convert from raw string to enum
+        return PushStatus[str(existing)]
+
     def __repr__(self):
         return f"{super(Push, self).__repr__()} rev='{self.rev}'"
 

--- a/mozci/util/taskcluster.py
+++ b/mozci/util/taskcluster.py
@@ -7,6 +7,7 @@ import os
 
 import taskcluster
 import taskcluster_urls as liburls
+from loguru import logger
 
 from mozci.util import yaml
 from mozci.util.req import get_session
@@ -124,3 +125,29 @@ def get_taskcluster_options():
         options["rootUrl"] = "https://community-tc.services.mozilla.com"
 
     return options
+
+
+def send_admin_emails(subject, content, emails):
+    """
+    Send an email to all provided email addresses
+    using Taskcluster notify service
+    """
+    if not emails:
+        logger.warn("No emails addresses available in configuration")
+        return
+
+    notify = taskcluster.Notify(get_taskcluster_options())
+
+    for idx, email in enumerate(emails):
+        try:
+            notify.email(
+                {
+                    "address": email,
+                    "subject": f"Mozci | {subject}",
+                    "content": content,
+                }
+            )
+        except Exception as e:
+            logger.warning(
+                f"Failed to send the report by email to address n°{idx} ({email}): {e}"
+            )


### PR DESCRIPTION
Closes #625 

The previus classification is retrieved from its indexed artifact, using a new data contract.

I moved the email sending code into taskcluster utils so that method is available to both `classify` and `classify-eval` command.

The email body is pretty simple and would render like this:

```
# Push 157518 evolved from GOOD to BAD

Rev: 46c23a830db14901758da2b09c144d6d1b0e2ad7

## Real failures

- linux64-test/whatever

```