### PR TITLE
Pretend there were no manual classifications when evaluating the autoclassification results

### DIFF
--- a/mozci/console/commands/push.py
+++ b/mozci/console/commands/push.py
@@ -280,6 +280,11 @@ class ClassifyEvalCommand(Command):
         self.errors = {}
         self.classifications = {}
         for push in self.pushes:
+            # Pretend no tasks were classified to evaluate the model without any outside help.
+            for task in push.tasks:
+                task.classification = "not classified"
+                task.classification_note = None
+
             if self.option("recalculate"):
                 progress.set_message(f"Calc. {branch} {push.id}")
                 try:


### PR DESCRIPTION
Fixes #606

This is a bit of a hack, but adding an option for it all over the place that is only used during evaluation seemed a bit overkill.