### PR TITLE
Fix email scopes

### DIFF
--- a/mozci/console/commands/decision.py
+++ b/mozci/console/commands/decision.py
@@ -76,6 +76,7 @@ class DecisionCommand(Command):
             "scopes": [
                 "docker-worker:cache:mozci-classifications-testing",
                 "secrets:get:project/mozci/testing",
+                "notify:email:*",
             ],
             "metadata": {
                 "name": f"mozci classify {push.branch}@{push.rev}",

--- a/mozci/data/sources/taskcluster/__init__.py
+++ b/mozci/data/sources/taskcluster/__init__.py
@@ -126,7 +126,8 @@ class TaskclusterSource(DataSource):
 
     def run_push_existing_classification(self, branch, rev):
         try:
-            index = Index(taskcluster.get_taskcluster_options())
+            # Proxy authentication does not seem to work here
+            index = Index({"rootUrl": taskcluster.COMMUNITY_TASKCLUSTER_ROOT_URL})
             response = index.findArtifactFromTask(
                 f"project.mozci.classification.{branch}.revision.{rev}",
                 "public/classification.json",


### PR DESCRIPTION
This should fix the auth error we are seeing on [current tasks](https://community-tc.services.mozilla.com/tasks/XmPemN9jSLSs4YGltugLhg/runs/0/logs/public/logs/live.log)

And also allow the children task to actually send emails (once https://github.com/mozilla/community-tc-config/pull/464 is applied)