### PR TITLE
Add an option to take into account failures happening consistently on a given configuration when classifying pushes

### DIFF
--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -1143,7 +1143,7 @@ def test_classify_almost_good_push(monkeypatch, test_selection_data, are_cross_c
         are_cross_config,
     )
 
-    assert push.classify(unknown_from_regressions=False) == (
+    assert push.classify(unknown_from_regressions=False, consistent_failures_counts=None) == (
         PushStatus.UNKNOWN,
         Regressions(
             real={},
@@ -1246,7 +1246,7 @@ def test_classify_almost_bad_push(
         are_cross_config,
     )
 
-    assert push.classify(unknown_from_regressions=False) == (
+    assert push.classify(unknown_from_regressions=False, consistent_failures_counts=None) == (
         PushStatus.UNKNOWN,
         Regressions(
             real={},


### PR DESCRIPTION
To identify real failures, we check that at least three tasks on any configuration are exhibiting the failure.
To identify intermittent failures, we check that there are no configurations with two tasks exhibiting the failure.
The numbers are configurable through the parameters to the push classify function.

Fixes #607