### PR TITLE
Support environment option

### DIFF
--- a/mozci/console/commands/decision.py
+++ b/mozci/console/commands/decision.py
@@ -19,7 +19,7 @@ class DecisionCommand(Command):
         {branch=autoland : Branch the push belongs to (e.g autoland, try, etc).}
         {--nb-pushes=15 : Do not create tasks on taskcluster, simply output actions.}
         {--dry-run : Do not create tasks on taskcluster, simply output actions.}
-        {--environment=testing : Environment to analyze (testing, production, ...)}
+        {--environment=testing : Environment in which the analysis is running (testing, production, ...)}
     """
 
     def handle(self):

--- a/mozci/console/commands/push.py
+++ b/mozci/console/commands/push.py
@@ -126,7 +126,7 @@ class ClassifyCommand(Command):
         {--high-confidence=0.9 : High confidence threshold used to classify the regressions.}
         {--output= : Path towards a directory to save a JSON file containing classification and regressions details in.}
         {--show-intermittents : If set, print tasks that should be marked as intermittent.}
-        {--environment=testing : Environment to analyze (testing, production, ...)}
+        {--environment=testing : Environment in which the analysis is running (testing, production, ...)}
     """
 
     def handle(self) -> None:
@@ -319,7 +319,7 @@ class ClassifyEvalCommand(Command):
         {--output= : Path towards a path to save a CSV file with classification states for various pushes.}
         {--send-email : If set, also send the evaluation report by email instead of just logging it.}
         {--detailed-classifications : If set, compare real/intermittent group classifications with Sheriff's ones.}
-        {--environment=testing : Environment to analyze (testing, production, ...)}
+        {--environment=testing : Environment in which the analysis is running (testing, production, ...)}
     """
 
     def handle(self) -> None:
@@ -640,7 +640,7 @@ class ClassifyPerfCommand(Command):
     Generate a CSV file with performance stats for all classification tasks
 
     perf
-        {--environment=testing : Environment to analyze (testing, production, ...)}
+        {--environment=testing : Environment in which the analysis is running (testing, production, ...)}
         {--output=perfs.csv: Output CSV file path}
     """
 

--- a/mozci/console/commands/push.py
+++ b/mozci/console/commands/push.py
@@ -126,6 +126,7 @@ class ClassifyCommand(Command):
         {--high-confidence=0.9 : High confidence threshold used to classify the regressions.}
         {--output= : Path towards a directory to save a JSON file containing classification and regressions details in.}
         {--show-intermittents : If set, print tasks that should be marked as intermittent.}
+        {--environment=testing : Environment to analyze (testing, production, ...)}
     """
 
     def handle(self) -> None:
@@ -229,7 +230,9 @@ class ClassifyCommand(Command):
             if emails:
                 # Load previous classification from taskcluster
                 try:
-                    previous = push.get_existing_classification()
+                    previous = push.get_existing_classification(
+                        self.option("environment")
+                    )
                 except SourcesNotFound:
                     # We still want to send a notification if the current one is bad
                     previous = None
@@ -316,6 +319,7 @@ class ClassifyEvalCommand(Command):
         {--output= : Path towards a path to save a CSV file with classification states for various pushes.}
         {--send-email : If set, also send the evaluation report by email instead of just logging it.}
         {--detailed-classifications : If set, compare real/intermittent group classifications with Sheriff's ones.}
+        {--environment=testing : Environment to analyze (testing, production, ...)}
     """
 
     def handle(self) -> None:

--- a/mozci/data/contract.py
+++ b/mozci/data/contract.py
@@ -204,6 +204,7 @@ _contracts: Tuple[Contract, ...] = (
             {
                 "branch": v.Str(),
                 "rev": v.Str(),
+                "environment": v.Str(),
             }
         ),
         validate_out=v.Str(options=["GOOD", "BAD", "UNKNOWN"]),

--- a/mozci/data/sources/taskcluster/__init__.py
+++ b/mozci/data/sources/taskcluster/__init__.py
@@ -124,12 +124,19 @@ class TaskclusterSource(DataSource):
 
         return results
 
-    def run_push_existing_classification(self, branch, rev):
+    def run_push_existing_classification(self, branch, rev, environment):
+        # Non-production environments are exposed in sub routes
+        route_prefix = (
+            "project.mozci.classification"
+            if environment == "production"
+            else f"project.mozci.{environment}.classification"
+        )
+
         try:
             # Proxy authentication does not seem to work here
             index = Index({"rootUrl": taskcluster.COMMUNITY_TASKCLUSTER_ROOT_URL})
             response = index.findArtifactFromTask(
-                f"project.mozci.classification.{branch}.revision.{rev}",
+                f"{route_prefix}.{branch}.revision.{rev}",
                 "public/classification.json",
             )
         except TaskclusterRestFailure as e:

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -1265,13 +1265,16 @@ class Push:
             "push_test_selection_data", branch=self.branch, rev=self.rev
         )
 
-    def get_existing_classification(self) -> PushStatus:
+    def get_existing_classification(self, environment: str) -> PushStatus:
         """Retrieves existing classification from Taskcluster artifacts
 
         Do not memoize this method as the classification may change every few minutes remotely
         """
         existing = data.handler.get(
-            "push_existing_classification", branch=self.branch, rev=self.rev
+            "push_existing_classification",
+            branch=self.branch,
+            rev=self.rev,
+            environment=environment,
         )
 
         # Convert from raw string to enum


### PR DESCRIPTION
This generalize the existing code to support various Taskcluster environments.

We would have:
- `testing` running as currently, except all classification tasks routes are prefixed with `testing` 
- `production` would need to be created and will run a dedicated branch build (named `production`).

Current classifications tasks would be promoted to production, so we have the longest history possible