### PR TITLE
Support environment in classify-eval

### DIFF
--- a/mozci/console/commands/decision.py
+++ b/mozci/console/commands/decision.py
@@ -109,6 +109,7 @@ class DecisionCommand(Command):
                     push.branch,
                     f"--rev={push.rev}",
                     "--output=/tmp",
+                    f"--environment={environment}",
                 ],
                 "cache": {
                     f"mozci-classifications-{environment}": "/cache",

--- a/mozci/console/commands/push.py
+++ b/mozci/console/commands/push.py
@@ -20,7 +20,6 @@ from mozci.push import Push, PushStatus, Regressions, make_push_objects
 from mozci.task import Task, TestTask
 from mozci.util.taskcluster import (
     COMMUNITY_TASKCLUSTER_ROOT_URL,
-    get_taskcluster_notify_service,
     get_taskcluster_options,
     notify_email,
     notify_matrix,
@@ -292,7 +291,6 @@ class ClassifyCommand(Command):
             previous == PushStatus.BAD
             and current in (PushStatus.GOOD, PushStatus.UNKNOWN)
         ):
-            notify = get_taskcluster_notify_service()
             email_content = EMAIL_PUSH_EVOLUTION.format(
                 previous=previous.name if previous else "no classification",
                 current=current.name,
@@ -307,14 +305,12 @@ class ClassifyCommand(Command):
             )
             if emails:
                 notify_email(
-                    notify_service=notify,
                     emails=emails,
                     subject=f"Push status evolution {push.id} {push.rev[:8]}",
                     content=email_content,
                 )
             if matrix_room:
                 notify_matrix(
-                    notify_service=notify,
                     room=matrix_room,
                     body=email_content,
                 )

--- a/mozci/util/taskcluster.py
+++ b/mozci/util/taskcluster.py
@@ -127,11 +127,7 @@ def get_taskcluster_options():
     return options
 
 
-def get_taskcluster_notify_service():
-    return taskcluster.Notify(get_taskcluster_options())
-
-
-def notify_email(notify_service, subject, content, emails):
+def notify_email(subject, content, emails):
     """
     Send an email to all provided email addresses
     using Taskcluster notify service
@@ -140,6 +136,7 @@ def notify_email(notify_service, subject, content, emails):
         logger.warning("No email address available in configuration")
         return
 
+    notify_service = taskcluster.Notify(get_taskcluster_options())
     for idx, email in enumerate(emails):
         try:
             notify_service.email(
@@ -155,7 +152,7 @@ def notify_email(notify_service, subject, content, emails):
             )
 
 
-def notify_matrix(notify_service, body, room):
+def notify_matrix(body, room):
     """
     Send a message on the provided Matrix room
     using Taskcluster notify service
@@ -164,6 +161,7 @@ def notify_matrix(notify_service, body, room):
         logger.warning("No Matrix room available in configuration")
         return
 
+    notify_service = taskcluster.Notify(get_taskcluster_options())
     try:
         notify_service.matrix({"roomId": room, "body": body})
     except Exception as e:


### PR DESCRIPTION
While fixing current issues on prod environment (https://github.com/mozilla/community-tc-config/pull/466) I noticed that the `classify-eval` was always using production index for existing pushes.

I also added the environment in the email subject.