### PR TITLE
Add an option to define the minimum number of configurations to consider a failure as cross-config

### DIFF
--- a/mozci/push.py
+++ b/mozci/push.py
@@ -1051,6 +1051,7 @@ class Push:
         real_confidence_threshold: float = 0.9,
         use_possible_regressions: bool = False,
         unknown_from_regressions: bool = True,
+        cross_config_counts: Optional[Tuple[int, int]] = (2, 2),
         consistent_failures_counts: Optional[Tuple[int, int]] = (2, 3),
     ) -> Regressions:
         """
@@ -1103,7 +1104,10 @@ class Push:
         groups_relevant_failure = {
             g.name
             for g in all_groups
-            if g.is_cross_config_failure
+            if (
+                cross_config_counts is not None
+                and g.is_cross_config_failure(cross_config_counts[1])
+            )
             or (
                 consistent_failures_counts is not None
                 and g.is_config_consistent_failure(consistent_failures_counts[1])
@@ -1114,7 +1118,10 @@ class Push:
             for g in all_groups
             if g.status != Status.PASS
             and (
-                g.is_cross_config_failure is False
+                (
+                    cross_config_counts is not None
+                    and g.is_cross_config_failure(cross_config_counts[0]) is False
+                )
                 or (
                     consistent_failures_counts is not None
                     and g.is_config_consistent_failure(consistent_failures_counts[0])
@@ -1186,6 +1193,7 @@ class Push:
         real_confidence_threshold: float = 0.9,
         use_possible_regressions: bool = False,
         unknown_from_regressions: bool = True,
+        cross_config_counts: Optional[Tuple[int, int]] = (2, 2),
         consistent_failures_counts: Optional[Tuple[int, int]] = (2, 3),
     ) -> Tuple[PushStatus, Regressions]:
         """
@@ -1200,6 +1208,7 @@ class Push:
             real_confidence_threshold,
             use_possible_regressions,
             unknown_from_regressions,
+            cross_config_counts,
             consistent_failures_counts,
         )
 

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -464,7 +464,7 @@ class GroupSummary(RunnableSummary):
                 if result.group == self.name:
                     config_to_results[task.configuration].append(result.ok)
 
-        # If there is no config for which we have at least two runs, return None (that is, unknown).
+        # If there is no config for which we have at least 'minimum_count' runs, return None (that is, unknown).
         if all(len(results) < minimum_count for results in config_to_results.values()):
             return None
 
@@ -474,8 +474,7 @@ class GroupSummary(RunnableSummary):
             for results in config_to_results.values()
         )
 
-    @memoized_property
-    def is_cross_config_failure(self) -> Optional[bool]:
+    def is_cross_config_failure(self, minimum_count: int = 2) -> Optional[bool]:
         states = [
             result.ok
             for task in self.tasks
@@ -487,8 +486,8 @@ class GroupSummary(RunnableSummary):
         nb_passed = sum(states)  # Number of True booleans in the states list
         nb_failed = nb - nb_passed
 
-        # If the group run on a single task, we don't have enough information to tell.
-        if nb <= 1:
+        # If the group run on fewer than 'minimum_count' tasks, we don't have enough information to tell.
+        if nb < minimum_count:
             return None
 
         # A group is a cross config failure when it is failing in all tasks and not

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -1097,7 +1097,11 @@ def generate_mocks(
 
     push.group_summaries = GROUP_SUMMARIES_DEFAULT
     for index, group in enumerate(push.group_summaries.values()):
-        group.is_cross_config_failure = cross_config_values[index]
+        monkeypatch.setattr(
+            group,
+            "is_cross_config_failure",
+            lambda x, index=index: cross_config_values[index],
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -368,7 +368,7 @@ def test_results_for_incomplete_task(responses):
     ],
 )
 def test_GroupSummary_is_cross_config_failure(group_summary, expected_result):
-    assert group_summary.is_cross_config_failure == expected_result
+    assert group_summary.is_cross_config_failure(2) == expected_result
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The option can be None if we want to disable cross-config detection, or a tuple with two ints where:
- the first number specifies the number of configurations to consider a failure as cross-config for intermittent detection;
- the second number specifies the number of configurations to consider a failure as cross-config for real failure detection.

This way we can tune the detection. E.g. if we want to be conservative, we can set a low first number and a high second number.

Fixes #605