### PR TITLE
Fix intermittent detection logic

### DIFF
--- a/mozci/push.py
+++ b/mozci/push.py
@@ -1119,12 +1119,12 @@ class Push:
             if g.status != Status.PASS
             and (
                 (
-                    cross_config_counts is not None
-                    and g.is_cross_config_failure(cross_config_counts[0]) is False
+                    cross_config_counts is None
+                    or g.is_cross_config_failure(cross_config_counts[0]) is False
                 )
-                or (
-                    consistent_failures_counts is not None
-                    and g.is_config_consistent_failure(consistent_failures_counts[0])
+                and (
+                    consistent_failures_counts is None
+                    or g.is_config_consistent_failure(consistent_failures_counts[0])
                     is False
                 )
             )

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -1102,6 +1102,11 @@ def generate_mocks(
             "is_cross_config_failure",
             lambda x, index=index: cross_config_values[index],
         )
+        monkeypatch.setattr(
+            group,
+            "is_config_consistent_failure",
+            lambda x, index=index: cross_config_values[index],
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
A failure is intermittent when it is not cross-config *and* not config-consistent, we were instead
checking if it was either not cross-config or not config-consistent.