### PR TITLE
Don't eat errors during push classification + Notify by email on TC task failure

### DIFF
--- a/mozci/console/commands/decision.py
+++ b/mozci/console/commands/decision.py
@@ -86,6 +86,7 @@ class DecisionCommand(Command):
             "scopes": [
                 f"docker-worker:cache:mozci-classifications-{environment}",
                 f"secrets:get:project/mozci/{environment}",
+                "queue:route:notify.email.release-mgmt-analysis@mozilla.com.on-failed",
                 "notify:email:*",
                 "notify:matrix-room:!vNAdpBnFtfGfispLtR:mozilla.org",
             ],
@@ -128,6 +129,7 @@ class DecisionCommand(Command):
             "routes": [
                 f"{route_prefix}.{push.branch}.revision.{push.rev}",
                 f"{route_prefix}.{push.branch}.push.{push.id}",
+                "notify.email.release-mgmt-analysis@mozilla.com.on-failed",
             ],
             "provisionerId": self.current_task["provisionerId"],
             "workerType": self.current_task["workerType"],

--- a/mozci/console/commands/push.py
+++ b/mozci/console/commands/push.py
@@ -141,27 +141,23 @@ class ClassifyCommand(Command):
     def handle(self) -> None:
         self.branch = self.argument("branch")
 
-        try:
-            pushes = classify_commands_pushes(
-                self.branch,
-                self.option("from-date"),
-                self.option("to-date"),
-                self.option("rev"),
-            )
-        except Exception as error:
-            self.line(f"<error>{error}</error>")
-            return
+        pushes = classify_commands_pushes(
+            self.branch,
+            self.option("from-date"),
+            self.option("to-date"),
+            self.option("rev"),
+        )
 
         try:
             medium_conf = float(self.option("medium-confidence"))
         except ValueError:
             self.line("<error>Provided --medium-confidence should be a float.</error>")
-            return
+            raise
         try:
             high_conf = float(self.option("high-confidence"))
         except ValueError:
             self.line("<error>Provided --high-confidence should be a float.</error>")
-            return
+            raise
 
         retrigger_unknown = True if self.option("retrigger-unknown") else False
         output = self.option("output")
@@ -343,17 +339,13 @@ class ClassifyEvalCommand(Command):
     def handle(self) -> None:
         branch = self.argument("branch")
 
-        try:
-            self.line("<comment>Loading pushes...</comment>")
-            self.pushes = classify_commands_pushes(
-                branch,
-                self.option("from-date"),
-                self.option("to-date"),
-                self.option("rev"),
-            )
-        except Exception as error:
-            self.line(f"<error>{error}</error>")
-            return
+        self.line("<comment>Loading pushes...</comment>")
+        self.pushes = classify_commands_pushes(
+            branch,
+            self.option("from-date"),
+            self.option("to-date"),
+            self.option("rev"),
+        )
 
         if self.option("recalculate"):
             try:
@@ -366,7 +358,7 @@ class ClassifyEvalCommand(Command):
                 self.line(
                     "<error>Provided --medium-confidence should be a float.</error>"
                 )
-                return
+                raise
             try:
                 high_conf = (
                     float(self.option("high-confidence"))
@@ -377,7 +369,7 @@ class ClassifyEvalCommand(Command):
                 self.line(
                     "<error>Provided --high-confidence should be a float.</error>"
                 )
-                return
+                raise
         elif self.option("medium-confidence") or self.option("high-confidence"):
             self.line(
                 "<error>--recalculate isn't set, you shouldn't provide either --medium-confidence nor --high-confidence attributes.</error>"

--- a/mozci/console/commands/push.py
+++ b/mozci/console/commands/push.py
@@ -172,23 +172,17 @@ class ClassifyCommand(Command):
             )
 
         for push in pushes:
-            try:
-                classification, regressions = push.classify(
-                    intermittent_confidence_threshold=medium_conf,
-                    real_confidence_threshold=high_conf,
-                )
-                if retrigger_unknown:
-                    for _, tasks in regressions.unknown.items():
-                        retrigger(tasks=tasks, repeat_retrigger=1)
-                self.line(
-                    f"Push associated with the head revision {push.rev} on "
-                    f"the branch {self.branch} is classified as {classification.name}"
-                )
-            except Exception as e:
-                self.line(
-                    f"<error>Couldn't classify push {push.push_uuid}: {e}.</error>"
-                )
-                continue
+            classification, regressions = push.classify(
+                intermittent_confidence_threshold=medium_conf,
+                real_confidence_threshold=high_conf,
+            )
+            if retrigger_unknown:
+                for _, tasks in regressions.unknown.items():
+                    retrigger(tasks=tasks, repeat_retrigger=1)
+            self.line(
+                f"Push associated with the head revision {push.rev} on "
+                f"the branch {self.branch} is classified as {classification.name}"
+            )
 
             if self.option("show-intermittents"):
                 self.line("-" * 50)


### PR DESCRIPTION
Closes #616 

@marco-c Do you think we need a new PR on the **community-tc-config** repo to add the `on-failed` route to the [Decision task `grant` list](https://github.com/mozilla/community-tc-config/blob/main/config/projects/mozci.yml#L56)?

If so, should we send mails for production/testing fails or just for production ones?