### PR TITLE
Don't use classifications from tasks that didn't fail when comparing classifications

### DIFF
--- a/mozci/console/commands/push.py
+++ b/mozci/console/commands/push.py
@@ -732,8 +732,12 @@ class ClassifyEvalCommand(Command):
         missed = []
         for group in predicted_groups:
             classifications_set = set(
-                [c for c, _ in push.group_summaries[group].classifications]
+                task.classification
+                for task in push.group_summaries[group].tasks
+                if task.failed
             )
+            if len(classifications_set) == 0:
+                continue
             if classifications_set == {"not classified"}:
                 pending.append(group)
             elif len(classifications_set) != 1:


### PR DESCRIPTION
Tasks that didn't fail clearly don't have a classification. This was causing us to find
a lot of conflicting classifications just because of group failures that were happening
on a subset of configurations.

Fixes #675