### PR TITLE
Use m.text msgtype instead of default m.notice one for Matrix notification

### DIFF
--- a/mozci/util/taskcluster.py
+++ b/mozci/util/taskcluster.py
@@ -173,6 +173,7 @@ def notify_matrix(body, room):
                 "body": body,
                 "format": "org.matrix.custom.html",
                 "formattedBody": formatted_body,
+                "msgtype": "m.text",
             }
         )
     except Exception as e:

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -147,6 +147,7 @@ def test_classification_evolution(
             "body": email_content,
             "formattedBody": markdown2.markdown(email_content),
             "format": "org.matrix.custom.html",
+            "msgtype": "m.text",
         }
     else:
         # Check no email was sent


### PR DESCRIPTION
Closes #677 