### PR TITLE
Add filters to control autoclassification in JSON output from config

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -112,3 +112,26 @@ logging, while setting it to ``2`` enables trace logging.
 .. _TOML: http://github.com/toml-lang/toml
 .. _cachy: https://github.com/sdispater/cachy
 .. _cachy's configuration format: https://cachy.readthedocs.io/en/latest/configuration.html
+
+autoclassification
+``````````````````
+
+Mozci controls which push classification results can be automatically processed by third-party tools (like Treeherder), using a feature flag and a set of filters for test names.
+
+The feature can be fully disabled by setting `enabled` to `false`.
+
+.. code-block:: toml
+
+    [mozci.autoclassification]
+    enabled = true
+    test-suite-names = [
+      "test-linux64-*/opt-mochitest-*",
+      "*wpt*",
+    ]
+
+
+Each value in the list of `test-suite-names` support [fnmatch](https://docs.python.org/3/library/fnmatch.html#fnmatch.fnmatch) syntax to allow glob-like syntax (using `*` for wildcard and `?` for single characters).
+
+The configuration above will enable autoclassification for tests matching `test-linux64-*/opt-mochitest-*` or `*wpt*`
+
+Finally, the JSON classification output is extended to have an `autoclassify` boolean flag on each failure details payload, to check if this specific result should be processed.

--- a/mozci/configuration.py
+++ b/mozci/configuration.py
@@ -155,6 +155,7 @@ class Configuration(Mapping):
 
         # Check auto classification settings
         assert isinstance(self._config["autoclassification"]["enabled"], bool)
+        assert isinstance(self._config["autoclassification"]["test-suite-names"], list)
 
     def __len__(self):
         return len(self._config)

--- a/mozci/configuration.py
+++ b/mozci/configuration.py
@@ -109,6 +109,10 @@ class Configuration(Mapping):
     ) or os.environ.get("TASKCLUSTER_SECRET")
     DEFAULTS = {
         "merge": {
+            "autoclassification": {
+                "enabled": False,
+                "test-suite-names": [],
+            },
             "cache": {"retention": 1440},
         },  # minutes
         "replace": {
@@ -148,6 +152,9 @@ class Configuration(Mapping):
 
         self.cache = CustomCacheManager(self._config["cache"])
         self.locked = True
+
+        # Check auto classification settings
+        assert isinstance(self._config["autoclassification"]["enabled"], bool)
 
     def __len__(self):
         return len(self._config)

--- a/mozci/console/commands/push.py
+++ b/mozci/console/commands/push.py
@@ -25,7 +25,7 @@ from mozci.push import (
     make_push_objects,
     retrigger,
 )
-from mozci.task import Task, TestTask
+from mozci.task import Task, TestTask, is_autoclassifiable
 from mozci.util.taskcluster import (
     COMMUNITY_TASKCLUSTER_ROOT_URL,
     get_taskcluster_options,
@@ -206,7 +206,7 @@ class ClassifyCommand(Command):
                             {
                                 "task_id": task.id,
                                 "label": task.label,
-                                "autoclassify": task.autoclassify,
+                                "autoclassify": is_autoclassifiable(task),
                             }
                             for task in failing_tasks
                         ]

--- a/mozci/console/commands/push.py
+++ b/mozci/console/commands/push.py
@@ -199,33 +199,32 @@ class ClassifyCommand(Command):
                 self.line("-" * 50)
 
             if output:
+
+                def _serialize_regressions(regressions):
+                    return {
+                        group: [
+                            {
+                                "task_id": task.id,
+                                "label": task.label,
+                                "autoclassify": task.autoclassify,
+                            }
+                            for task in failing_tasks
+                        ]
+                        for group, failing_tasks in regressions.items()
+                    }
+
                 to_save = {
+                    "autoclassification": config["autoclassification"]["enabled"],
                     "push": {
                         "id": push.push_uuid,
                         "classification": classification.name,
                     },
                     "failures": {
-                        "real": {
-                            group: [
-                                {"task_id": task.id, "label": task.label}
-                                for task in failing_tasks
-                            ]
-                            for group, failing_tasks in regressions.real.items()
-                        },
-                        "intermittent": {
-                            group: [
-                                {"task_id": task.id, "label": task.label}
-                                for task in failing_tasks
-                            ]
-                            for group, failing_tasks in regressions.intermittent.items()
-                        },
-                        "unknown": {
-                            group: [
-                                {"task_id": task.id, "label": task.label}
-                                for task in failing_tasks
-                            ]
-                            for group, failing_tasks in regressions.unknown.items()
-                        },
+                        "real": _serialize_regressions(regressions.real),
+                        "intermittent": _serialize_regressions(
+                            regressions.intermittent
+                        ),
+                        "unknown": _serialize_regressions(regressions.unknown),
                     },
                 }
 

--- a/mozci/console/commands/push.py
+++ b/mozci/console/commands/push.py
@@ -214,7 +214,6 @@ class ClassifyCommand(Command):
                     }
 
                 to_save = {
-                    "autoclassification": config["autoclassification"]["enabled"],
                     "push": {
                         "id": push.push_uuid,
                         "classification": classification.name,

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -124,6 +124,19 @@ def is_bad_group(task_id: str, group: str) -> bool:
     return bad_group
 
 
+def is_autoclassifiable(task: Task) -> bool:
+    """Check a task is enabled for auto-classification
+    by applying glob patterns from configuration
+    """
+    if not task.label or not config["autoclassification"]["enabled"]:
+        return False
+
+    return any(
+        fnmatch.fnmatch(task.label, pattern)
+        for pattern in config["autoclassification"]["test-suite-names"]
+    )
+
+
 # Transform WPT group names to a full relative path in mozilla-central.
 def wpt_workaround(group: str) -> str:
     # No need to transform empty groups (also, they will be filtered out
@@ -195,19 +208,6 @@ class Task:
     def artifacts(self):
         """List the artifacts that were uploaded by this task."""
         return [artifact["name"] for artifact in list_artifacts(self.id)]
-
-    @property
-    def autoclassify(self):
-        """Check this task is enabled for auto-classification
-        by applying glob patterns from configuration
-        """
-        if not self.label or not config["autoclassification"]["enabled"]:
-            return False
-
-        return any(
-            fnmatch.fnmatch(self.label, pattern)
-            for pattern in config["autoclassification"]["test-suite-names"]
-        )
 
     def get_artifact(self, path, root_url=PRODUCTION_TASKCLUSTER_ROOT_URL):
         """Downloads and returns the content of an artifact.

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -128,7 +128,9 @@ def is_autoclassifiable(task: Task) -> bool:
     """Check a task is enabled for auto-classification
     by applying glob patterns from configuration
     """
-    if not task.label or not config["autoclassification"]["enabled"]:
+    assert task.label, "Missing task label"
+
+    if not config["autoclassification"]["enabled"]:
         return False
 
     return any(

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -7,7 +7,7 @@ import pytest
 
 from mozci import config
 from mozci.errors import ArtifactNotFound, TaskNotFound
-from mozci.task import GroupResult, GroupSummary, Task
+from mozci.task import GroupResult, GroupSummary, Task, is_autoclassifiable
 from mozci.util.taskcluster import get_artifact_url, get_index_url
 
 GR_2 = GroupResult(group="group2", ok=True, duration=42)
@@ -592,4 +592,4 @@ def test_autoclassify(enabled, filters, result):
     task = Task.create(
         id="someId", label="test-macosx1015-64/opt-xpcshell-e10s-something"
     )
-    assert task.autoclassify is result
+    assert is_autoclassifiable(task) is result


### PR DESCRIPTION
Refs #665 

This extends the mozci configuration to support autoclassification parameters to enable/disable the feature globally, and filter out which test will be enabled.

```toml
[mozci.autoclassification]
enabled = true
test-suite-names = ["test-linux64*/opt-mochitest-*"]
```

The filter support [fnmatch](https://docs.python.org/3/library/fnmatch.html#fnmatch.fnmatch) syntax to allow glob-like syntax (using `*` for wildcard and `?` for single characters).

The configuration above will enable autoclassification for test matching `test-linux64*/opt-mochitest-*`

Finally, the JSON classification output is extended to have:
~~- a top level `autoclassification` boolean flag to check if the results should processed at all,~~
- an `autoclassify` boolean flag on each failure details payload, to check if this specific result should be processed.