### PR TITLE
Add a default 'failure-types' configuration under 'autoclassification'

### DIFF
--- a/mozci/configuration.py
+++ b/mozci/configuration.py
@@ -112,6 +112,7 @@ class Configuration(Mapping):
             "autoclassification": {
                 "enabled": False,
                 "test-suite-names": [],
+                "failure-types": [],
             },
             "cache": {"retention": 1440},
         },  # minutes


### PR DESCRIPTION
Fixes #707