### PR TITLE
Temporarily allow groups with no name

### DIFF
--- a/mozci/data/contract.py
+++ b/mozci/data/contract.py
@@ -137,8 +137,9 @@ _contracts: Tuple[Contract, ...] = (
             }
         ),
         validate_out=v.Dict(
+            # TODO: 'minlen=1' can be added to v.Str(), the group name, once we stop seeing groups with empty names.
             # TODO: 'nullable=True' can be removed once https://github.com/mozilla/mozci/issues/662 is fixed.
-            extra=(v.Str(minlen=1), v.Tuple(v.Bool(), v.Int(nullable=True)))
+            extra=(v.Str(), v.Tuple(v.Bool(), v.Int(nullable=True)))
         ),
     ),
     Contract(


### PR DESCRIPTION
Fixes #709

We already skip them, and log an error about them, in https://github.com/mozilla/mozci/blob/df413c054baba820f43ed3dc7f86be4d10826a78/mozci/task.py#L112. So, temporarily allowing empty group names to pass validation as a workaround for the problem won't have any countereffects.