### PR TITLE
Switch to using index.buildUrl and manual requests.get instead of relying on the taskcluster library to get the artifact

### DIFF
--- a/mozci/data/sources/taskcluster/__init__.py
+++ b/mozci/data/sources/taskcluster/__init__.py
@@ -150,7 +150,7 @@ class TaskclusterSource(DataSource):
             )
 
         try:
-            r = requests.get(url)
+            r = requests.get(url, allow_redirects=True)
             r.raise_for_status()
         except requests.exceptions.HTTPError as e:
             raise ContractNotFilled(

--- a/mozci/data/sources/taskcluster/__init__.py
+++ b/mozci/data/sources/taskcluster/__init__.py
@@ -132,6 +132,8 @@ class TaskclusterSource(DataSource):
             else f"project.mozci.{environment}.classification"
         )
 
+        # We use buildUrl and manual requests.get instead of directly findArtifactFromTask from the taskcluster library
+        # because the taskcluster library fails with redirects (https://github.com/taskcluster/taskcluster/issues/4998).
         try:
             # Proxy authentication does not seem to work here
             index = Index({"rootUrl": taskcluster.COMMUNITY_TASKCLUSTER_ROOT_URL})

--- a/mozci/data/sources/taskcluster/__init__.py
+++ b/mozci/data/sources/taskcluster/__init__.py
@@ -135,7 +135,8 @@ class TaskclusterSource(DataSource):
         try:
             # Proxy authentication does not seem to work here
             index = Index({"rootUrl": taskcluster.COMMUNITY_TASKCLUSTER_ROOT_URL})
-            response = index.findArtifactFromTask(
+            url = index.buildUrl(
+                "findArtifactFromTask",
                 f"{route_prefix}.{branch}.revision.{rev}",
                 "public/classification.json",
             )
@@ -147,7 +148,17 @@ class TaskclusterSource(DataSource):
             )
 
         try:
-            return response["push"]["classification"]
+            r = requests.get(url)
+            r.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            raise ContractNotFilled(
+                self.name,
+                "push_existing_classification",
+                f"Failed to load existing classification for {branch} {rev}: {e}",
+            )
+
+        try:
+            return r.json()["push"]["classification"]
         except KeyError:
             raise ContractNotFilled(
                 self.name, "push_existing_classification", "Invalid classification data"


### PR DESCRIPTION
The taskcluster library is failing on 303.

Fixes #737