### PR TITLE
Consider "autoclassified intermittent" as "intermittent"

### DIFF
--- a/mozci/console/commands/push.py
+++ b/mozci/console/commands/push.py
@@ -28,6 +28,7 @@ from mozci.push import (
     retrigger,
 )
 from mozci.task import Task, TestTask, is_autoclassifiable
+from mozci.util.defs import INTERMITTENT_CLASSES
 from mozci.util.taskcluster import (
     COMMUNITY_TASKCLUSTER_ROOT_URL,
     get_taskcluster_options,
@@ -637,7 +638,7 @@ class ClassifyEvalCommand(Command):
                     sheriff_intermittents = set()
                     for name, group in push.group_summaries.items():
                         classifications = set([c for c, _ in group.classifications])
-                        if classifications == {"intermittent"}:
+                        if classifications <= set(INTERMITTENT_CLASSES):
                             sheriff_intermittents.add(name)
                 except Exception:
                     self.line(
@@ -649,7 +650,7 @@ class ClassifyEvalCommand(Command):
                         push,
                         "intermittent",
                         sheriff_intermittents,
-                        {"intermittent"},
+                        set(INTERMITTENT_CLASSES),
                     )
                     intermittent_stats = {
                         key: value + push_intermittent_stats[key]
@@ -797,7 +798,7 @@ class ClassifyEvalCommand(Command):
                 pending.append(group)
             elif len(classifications_set) != 1:
                 conflicting.append(group)
-            elif classifications_set != expected:
+            elif classifications_set.isdisjoint(expected):
                 differing.append(group)
 
         for group in sheriff_groups:

--- a/mozci/push.py
+++ b/mozci/push.py
@@ -28,6 +28,7 @@ from mozci.task import (
     TestTask,
     get_configuration_from_label,
 )
+from mozci.util.defs import FAILURE_CLASSES
 from mozci.util.hgmo import HgRev, parse_bugs
 from mozci.util.memoize import memoize, memoized_property
 
@@ -37,8 +38,6 @@ MAX_DEPTH = config.get("maxdepth", 20)
 """The maximum number of parents or children to look for previous/next task runs,
 when the task did not run on the currently considered push.
 """
-
-FAILURE_CLASSES = ("not classified", "fixed by commit")
 
 
 class PushStatus(Enum):

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -19,6 +19,7 @@ from loguru import logger
 
 from mozci import config, data
 from mozci.errors import ArtifactNotFound, TaskNotFound
+from mozci.util.defs import INTERMITTENT_CLASSES
 from mozci.util.memoize import memoized_property
 from mozci.util.taskcluster import (
     PRODUCTION_TASKCLUSTER_ROOT_URL,
@@ -300,7 +301,9 @@ class Task:
             context={
                 "taskId": self.id,
                 "taskGroupId": decision_task.id,
-                "input": {"times": 5 if self.classification == "intermittent" else 1},
+                "input": {
+                    "times": 5 if self.classification in INTERMITTENT_CLASSES else 1
+                },
             },
         )
 
@@ -457,7 +460,7 @@ class RunnableSummary(ABC):
     @property
     def is_intermittent(self):
         return self.status == Status.INTERMITTENT or any(
-            c == "intermittent" for c, n in self.classifications
+            c in INTERMITTENT_CLASSES for c, n in self.classifications
         )
 
     @property

--- a/mozci/util/defs.py
+++ b/mozci/util/defs.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+FAILURE_CLASSES = ("not classified", "fixed by commit")
+INTERMITTENT_CLASSES = ("intermittent", "autoclassified intermittent")


### PR DESCRIPTION
They are clearly not exactly the same, but we can assume "autoclassified intermittent" are good
enough to be used.

Fixes #770