### PR TITLE
Allow autoclassification when there are multiple failures of the same type reported for the same test

### DIFF
--- a/mozci/task.py
+++ b/mozci/task.py
@@ -148,11 +148,13 @@ def is_autoclassifiable(task: TestTask) -> bool:
         filtered_failure_types
     ).issubset(allowed_values), "Unsupported failure types in configuration"
 
-    flat_failure_types = [
-        test_and_type
-        for group in task.failure_types.values()
-        for test_and_type in group
-    ]
+    flat_failure_types = list(
+        set(
+            test_and_type
+            for group in task.failure_types.values()
+            for test_and_type in group
+        )
+    )
 
     return (
         any(

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -867,6 +867,9 @@ ONE_FAILURE_TYPE_GENERIC = {"group1": [("test1.js", FailureType.GENERIC)]}
 TWO_FAILURES_SAME_TEST_TYPE_GENERIC = {
     "group1": [("test1.js", FailureType.GENERIC), ("test1.js", FailureType.GENERIC)]
 }
+TWO_FAILURES_SAME_TEST_DIFFERENT_TYPE = {
+    "group1": [("test1.js", FailureType.GENERIC), ("test1.js", FailureType.CRASH)]
+}
 MULTIPLE_FAILURE_TYPES = {
     "group1": [("test1.js", FailureType.CRASH), ("test2.js", FailureType.CRASH)],
     "group2": [("test1.js", FailureType.GENERIC), ("test2.js", FailureType.TIMEOUT)],
@@ -942,6 +945,16 @@ MULTIPLE_FAILURE_TYPES = {
         (MULTIPLE_FAILURE_TYPES, True, ["*"], ["crash"], False),
         # Two generic failures in the same test.
         (TWO_FAILURES_SAME_TEST_TYPE_GENERIC, True, ["*"], ["generic"], True),
+        # A generic failure and a crash in the same test.
+        (TWO_FAILURES_SAME_TEST_DIFFERENT_TYPE, True, ["*"], ["generic"], False),
+        (TWO_FAILURES_SAME_TEST_DIFFERENT_TYPE, True, ["*"], ["crash"], False),
+        (
+            TWO_FAILURES_SAME_TEST_DIFFERENT_TYPE,
+            True,
+            ["*"],
+            ["generic", "crash"],
+            False,
+        ),
     ],
 )
 def test_autoclassify(

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -864,6 +864,9 @@ def test_autoclassify_errors(autoclassification_config, expected_error, error_me
 ONE_FAILURE_TYPE_CRASH = {"group1": [("test1.js", FailureType.CRASH)]}
 ONE_FAILURE_TYPE_TIMEOUT = {"group1": [("test1.js", FailureType.TIMEOUT)]}
 ONE_FAILURE_TYPE_GENERIC = {"group1": [("test1.js", FailureType.GENERIC)]}
+TWO_FAILURES_SAME_TEST_TYPE_GENERIC = {
+    "group1": [("test1.js", FailureType.GENERIC), ("test1.js", FailureType.GENERIC)]
+}
 MULTIPLE_FAILURE_TYPES = {
     "group1": [("test1.js", FailureType.CRASH), ("test2.js", FailureType.CRASH)],
     "group2": [("test1.js", FailureType.GENERIC), ("test2.js", FailureType.TIMEOUT)],
@@ -937,6 +940,8 @@ MULTIPLE_FAILURE_TYPES = {
         (ONE_FAILURE_TYPE_GENERIC, True, ["*"], ["crash", "timeout"], False),
         ({}, True, ["*"], ["crash"], False),
         (MULTIPLE_FAILURE_TYPES, True, ["*"], ["crash"], False),
+        # Two generic failures in the same test.
+        (TWO_FAILURES_SAME_TEST_TYPE_GENERIC, True, ["*"], ["generic"], True),
     ],
 )
 def test_autoclassify(


### PR DESCRIPTION
E.g. in https://firefoxci.taskcluster-artifacts.net/BApCu7UpRmyY0FguiQcacg/0/public/test_info/xpcshell_errorsummary.log we have:
```
{"test": "browser/components/migration/tests/unit/test_MigrationUtils_timedRetry.js", "subtest": null, "group": "browser/components/migration/tests/unit/xpcshell.ini", "status": "FAIL", "expected": "PASS", "message": "xpcshell return code: 0", "stack": null, "known_intermittent": [], "action": "test_result", "line": 4866}
{"test": "browser/components/migration/tests/unit/test_MigrationUtils_timedRetry.js", "subtest": "testgetRowsFromDBWithoutLocksRetries", "group": "browser/components/migration/tests/unit/xpcshell.ini", "status": "FAIL", "expected": "PASS", "message": "[testgetRowsFromDBWithoutLocksRetries : 270] A promise chain failed to handle a rejection: Error(s) encountered during statement execution: disk I/O error - stack: handleCompletion@resource://gre/modules/Sqlite.jsm:966:25\n_do_main@/opt/worker/tasks/task_165794438898619/build/tests/xpcshell/head.js:238:6\n_execute_test@/opt/worker/tasks/task_165794438898619/build/tests/xpcshell/head.js:595:5\n@-e:1:1\nRejection date: Sat Jul 16 2022 07:18:12 GMT+0000 (Greenwich Mean Time) - false == true", "stack": "resource://testing-common/PromiseTestUtils.jsm:assertNoUncaughtRejections:270\n/opt/worker/tasks/task_165794438898619/build/tests/xpcshell/head.js:_execute_test:596\n-e:null:1", "known_intermittent": [], "action": "test_result", "line": 4892}
```

Without this patch, autoclassification is disabled for this test.