### PR TITLE
add logic to mozci for using and triggering confirm failures

### DIFF
--- a/mozci/console/commands/push.py
+++ b/mozci/console/commands/push.py
@@ -438,7 +438,7 @@ class ClassifyCommand(Command):
             groups_with_failures.values(), 0, retrigger_limit
         ):
             # If there is more than one task failing in this group, we should retrigger only one of them
-            failing_tasks[0].retrigger(push, count)
+            failing_tasks[0].confirm(push)
 
     def backfill_and_retrigger_failures(
         self,


### PR DESCRIPTION
this is to show a WIP

I still need to:
 * create unittests
 * remove my hack for 2 days (needed that for a try push <8 hours old)
 * decide on logic for how to use cf tasks
