### PR TITLE
Migrate CI from Ubuntu 22.04 to Ubuntu 24.04

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -58,7 +58,7 @@ tasks:
       dependencies:
         - { $eval: as_slugid("tests_task") }
       provisionerId: proj-mozci
-      workerType: generic-worker-ubuntu-22-04
+      workerType: generic-worker-ubuntu-24-04
       payload:
         maxRunTime: 3600
         command:


### PR DESCRIPTION
We intend to remove support for Ubuntu 22.04, and are migrating all worker pools to Ubuntu 24.04. Let us know if that is a problem! Thanks. :-)