### PR TITLE
Store extra.treeherder.jobKind on Task

### DIFF
--- a/mozci/data/contract.py
+++ b/mozci/data/contract.py
@@ -56,8 +56,17 @@ _contracts: Tuple[Contract, ...] = (
                             "superseded",
                         ]
                     ),
+                    "job_kind": v.Str(),
                 },
-                optional=["duration", "result", "tier", "suite", "platform", "variant"],
+                optional=[
+                    "duration",
+                    "result",
+                    "tier",
+                    "suite",
+                    "platform",
+                    "variant",
+                    "job_kind",
+                ],
             )
         ),
     ),

--- a/mozci/data/sources/taskcluster/__init__.py
+++ b/mozci/data/sources/taskcluster/__init__.py
@@ -66,9 +66,13 @@ class TaskclusterSource(DataSource):
                 .get("runtime", {}),
             }
 
-            tier = result["task"]["extra"].get("treeherder", {}).get("tier")
+            treeherder = result["task"]["extra"].get("treeherder", {})
+            tier = treeherder.get("tier")
             if tier:
                 task["tier"] = tier
+            job_kind = treeherder.get("jobKind")
+            if job_kind:
+                task["job_kind"] = job_kind
 
             # Use the latest run (earlier ones likely had exceptions that
             # caused an automatic retry).

--- a/mozci/task.py
+++ b/mozci/task.py
@@ -216,6 +216,7 @@ class Task:
     suite: Optional[str] = field(default=None)
     platform: Optional[str] = field(default=None)
     variant: Optional[Dict] = field(default=None)
+    job_kind: Optional[str] = field(default=None)
 
     @staticmethod
     def create(index=None, root_url=PRODUCTION_TASKCLUSTER_ROOT_URL, **kwargs):

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -44,7 +44,7 @@ class Responses:
                     {
                         "task": {
                             "extra": {
-                                "treeherder": {"tier": 3},
+                                "treeherder": {"tier": 3, "jobKind": "test"},
                                 "suite": None,
                             },
                         },
@@ -75,7 +75,7 @@ class Responses:
                     {
                         "task": {
                             "extra": {
-                                "treeherder": {"tier": 3},
+                                "treeherder": {"tier": 3, "jobKind": "build"},
                                 "suite": "task",
                             },
                             "metadata": {
@@ -168,7 +168,7 @@ class Responses:
                     {
                         "task": {
                             "extra": {
-                                "treeherder": {"tier": 3},
+                                "treeherder": {"tier": 3, "jobKind": "build"},
                                 "suite": "task",
                             },
                             "metadata": {
@@ -191,7 +191,7 @@ class Responses:
                     {
                         "task": {
                             "extra": {
-                                "treeherder": {"tier": 3},
+                                "treeherder": {"tier": 3, "jobKind": "test"},
                                 "suite": "task",
                             },
                             "metadata": {
@@ -349,6 +349,7 @@ class Responses:
                     "state": "unscheduled",
                     "tags": {"name": "tag-A"},
                     "tier": 3,
+                    "job_kind": "build",
                 },
                 {
                     "id": "task-id-B",
@@ -402,6 +403,7 @@ class Responses:
                     "state": "completed",
                     "tags": {},
                     "tier": 3,
+                    "job_kind": "build",
                 },
                 {
                     "duration": 60000,
@@ -414,6 +416,7 @@ class Responses:
                     "state": "completed",
                     "tags": {},
                     "tier": 3,
+                    "job_kind": "test",
                 },
             ],
             id="taskcluster.push_tasks",


### PR DESCRIPTION
Part of #1145

This loads the `extra.treeherder.jobKind` from taskcluster task definition onto the `Task` class.