### PR TITLE
update push_revisions scheme to include 'git_node' and 'git_parents' returned by the server

### DIFF
--- a/mozci/data/contract.py
+++ b/mozci/data/contract.py
@@ -129,6 +129,8 @@ _contracts: Tuple[Contract, ...] = (
                                 "branch": v.Str(),
                                 "desc": v.Str(),
                                 "files": v.List(v.Str()),
+                                "git_node": v.Str(),
+                                "git_parents": v.List(v.Str()),
                                 "node": v.Str(),
                                 "parents": v.List(v.Str()),
                                 "tags": v.List(v.Str()),


### PR DESCRIPTION
Currently, this aborts mozci runs:

```
ERROR    | mozci.data.base:87  - Result from contract 'push_revisions' does not conform to schema!

<SchemaError(errors=[
    <0.revs.0.git_node: ForbiddenKeyError()>,
    <0.revs.0.git_parents: ForbiddenKeyError()>,
``