### PR TITLE
Prevent retriggering more than 15 failed build tasks

### DIFF
--- a/mozci/configuration.py
+++ b/mozci/configuration.py
@@ -108,7 +108,6 @@ class Configuration(Mapping):
     ) or os.environ.get("TASKCLUSTER_SECRET")
     DEFAULTS = {
         "merge": {
-            "maximum_build_tasks_to_retrigger": 15,
             "retriggerable-backfillable-task-names": [],
             "autoclassification": {
                 "enabled": False,

--- a/mozci/configuration.py
+++ b/mozci/configuration.py
@@ -108,6 +108,7 @@ class Configuration(Mapping):
     ) or os.environ.get("TASKCLUSTER_SECRET")
     DEFAULTS = {
         "merge": {
+            "maximum_build_tasks_to_retrigger": 15,
             "retriggerable-backfillable-task-names": [],
             "autoclassification": {
                 "enabled": False,

--- a/mozci/console/commands/push.py
+++ b/mozci/console/commands/push.py
@@ -317,7 +317,10 @@ class ClassifyCommand(BasePushCommand):
         ),
         option(
             "maximum_build_tasks_to_retrigger",
-            description="The maximum number of build task failures to retrigger for a single push",
+            description=(
+                "The maximum number of build task failures to retrigger for a single push. "
+                "The value can be set to -1 for no maximum."
+            ),
             flag=False,
             default=15,
         ),
@@ -357,16 +360,17 @@ class ClassifyCommand(BasePushCommand):
                         self.line("No build task detected as potential regression")
                     else:
                         max_retrigger = self.option("maximum_build_tasks_to_retrigger")
-                        if len(tasks_to_retrigger) > max_retrigger:
-                            # In case many build failures are observed, the issue is likely not
-                            # general intermittentness of the tasks if the tree/repository/project
-                            # is mozilla-central but either a permanent failure of the executed
-                            # task payload or an infrastructure, e.g. to access required resources
-                            self.line(
-                                f"<error> More than {max_retrigger} build tasks were detected as potential regressions. "
-                                "Only the first {max_retrigger} will be retriggered."
-                            )
-                        tasks_to_retrigger = tasks_to_retrigger[:max_retrigger]
+                        if max_retrigger > 0:
+                            if len(tasks_to_retrigger) > max_retrigger:
+                                # In case many build failures are observed, the issue is likely not
+                                # general intermittentness of the tasks if the tree/repository/project
+                                # is mozilla-central but either a permanent failure of the executed
+                                # task payload or an infrastructure, e.g. to access required resources
+                                self.line(
+                                    f"<error> More than {max_retrigger} build tasks were detected as potential regressions. "
+                                    "Only the first {max_retrigger} will be retriggered."
+                                )
+                            tasks_to_retrigger = tasks_to_retrigger[:max_retrigger]
                         self.line(
                             f"Retriggering {len(tasks_to_retrigger)} build regression that may introduce a build bustage"
                         )

--- a/mozci/console/commands/push.py
+++ b/mozci/console/commands/push.py
@@ -350,6 +350,17 @@ class ClassifyCommand(BasePushCommand):
                     if not tasks_to_retrigger:
                         self.line("No build task detected as potential regression")
                     else:
+                        max_retrigger = config["maximum_build_tasks_to_retrigger"]
+                        if len(tasks_to_retrigger) > max_retrigger:
+                            # In case many build failures are observed, the issue is likely not
+                            # general intermittentness of the tasks if the tree/repository/project
+                            # is mozilla-central but either a permanent failure of the executed
+                            # task payload or an infrastructure, e.g. to access required resources
+                            self.line(
+                                f"<error> More than {max_retrigger} build tasks were detected as potential regressions. "
+                                "Only the first {max_retrigger} will be retriggered."
+                            )
+                        tasks_to_retrigger = tasks_to_retrigger[:max_retrigger]
                         self.line(
                             f"Retriggering {len(tasks_to_retrigger)} build regression that may introduce a build bustage"
                         )

--- a/mozci/console/commands/push.py
+++ b/mozci/console/commands/push.py
@@ -315,6 +315,12 @@ class ClassifyCommand(BasePushCommand):
             description="If set, skip the analysis of build tasks regressions.",
             flag=True,
         ),
+        option(
+            "maximum_build_tasks_to_retrigger",
+            description="The maximum number of build task failures to retrigger for a single push",
+            flag=False,
+            default=15,
+        ),
     ]
 
     def handle(self) -> None:
@@ -350,7 +356,7 @@ class ClassifyCommand(BasePushCommand):
                     if not tasks_to_retrigger:
                         self.line("No build task detected as potential regression")
                     else:
-                        max_retrigger = config["maximum_build_tasks_to_retrigger"]
+                        max_retrigger = self.option("maximum_build_tasks_to_retrigger")
                         if len(tasks_to_retrigger) > max_retrigger:
                             # In case many build failures are observed, the issue is likely not
                             # general intermittentness of the tasks if the tree/repository/project


### PR DESCRIPTION
Closes #1188

The two initial points about build failure detection seems to be covered by #1167. The detection is based on the `jobKind` attribute being `"build"`, and result being one of `{"busted", "failed", "exception"}` .